### PR TITLE
Add host and port to server config

### DIFF
--- a/src/web_app_skeleton/config/server.cr.ecr
+++ b/src/web_app_skeleton/config/server.cr.ecr
@@ -4,6 +4,8 @@ Lucky::Server.configure do
   else
     settings.secret_key_base = "<%= secret_key_base %>"
   end
+  settings.host = "0.0.0.0"
+  settings.port = (ENV["PORT"]? || 8080).to_i
 end
 
 private def secret_key_from_env

--- a/src/web_app_skeleton/src/server.cr
+++ b/src/web_app_skeleton/src/server.cr
@@ -1,6 +1,9 @@
 require "./app"
 
-server = HTTP::Server.new("0.0.0.0", 8080, [
+host = Lucky::Server.settings.host
+port = Lucky::Server.settings.port
+
+server = HTTP::Server.new(host, port, [
   Lucky::HttpMethodOverrideHandler.new,
   Lucky::LogHandler.new,
   Lucky::SessionHandler.new,
@@ -10,6 +13,6 @@ server = HTTP::Server.new("0.0.0.0", 8080, [
   Lucky::StaticFileHandler.new("./public", false),
 ])
 
-puts "Listening on http://0.0.0.0:8080..."
+puts "Listening on http://#{host}:#{port}"
 
 server.listen


### PR DESCRIPTION
Use new config from: https://github.com/luckyframework/lucky/pull/249

* Default host is 0.0.0.0
* Default port uses PORT env or 8080. Out of the box Heroku support.
* Removes trailing ... when outputting the host/port. Makes it easier
copy/paste.