### PR TITLE
Install yarn dependencies silently

### DIFF
--- a/src/web_app_skeleton/bin/setup
+++ b/src/web_app_skeleton/bin/setup
@@ -23,6 +23,7 @@ indent() {
 
 echo "\n▸ Installing node dependencies"
 yarn install --silent | indent
+echo "\n▸ Done installing node dependencies"
 
 echo "\n▸ Compiling assets"
 bin/compile_assets build | indent

--- a/src/web_app_skeleton/bin/setup
+++ b/src/web_app_skeleton/bin/setup
@@ -22,7 +22,7 @@ indent() {
 }
 
 echo "\n▸ Installing node dependencies"
-yarn install | indent
+yarn install --silent | indent
 
 echo "\n▸ Compiling assets"
 bin/compile_assets build | indent


### PR DESCRIPTION
Yarn outputs significant noise while installing node dependencies.
Outputting excessively to STDOUT during normal operation can hide
relevant error messages from users.  Install yarn with silent flag so
only errors are outputted when running `yarn install`

See issue #23