### PR TITLE
Add LUCKY_ENV to spec_helper

### DIFF
--- a/spec/integration/init_web_spec.cr
+++ b/spec/integration/init_web_spec.cr
@@ -11,6 +11,7 @@ describe "Initializing a new web project" do
         should_run_successfully "crystal build src/server.cr"
         should_run_successfully "crystal build src/test_project.cr"
         should_run_successfully "crystal src/app.cr"
+        should_run_successfully "crystal spec"
       end
     ensure
       FileUtils.rm_rf "test-project"

--- a/src/generators/web.cr
+++ b/src/generators/web.cr
@@ -35,6 +35,7 @@ class LuckyCli::Generators::Web
     generate_default_crystal_project
     add_deps_to_shard_file
     remove_generated_src_files
+    remove_generatred_spec_files
     remove_default_readme
     add_default_lucky_structure_to_src
     setup_gitignore
@@ -73,6 +74,10 @@ class LuckyCli::Generators::Web
     FileUtils.rm_r("#{project_dir}/src")
   end
 
+  private def remove_generatred_spec_files
+    FileUtils.rm_r("#{project_dir}/spec")
+  end
+
   private def remove_default_readme
     FileUtils.rm_r("#{project_dir}/README.md")
   end
@@ -105,10 +110,10 @@ class LuckyCli::Generators::Web
     DEPS_LIST
   end
 
-    private def ensure_directory_does_not_exist
-      if Dir.exists?("./#{project_dir}")
-        puts "Folder named #{project_name} already exists, please use a different name"
-        exit
-      end
+  private def ensure_directory_does_not_exist
+    if Dir.exists?("./#{project_dir}")
+      puts "Folder named #{project_name} already exists, please use a different name"
+      exit
     end
+  end
 end

--- a/src/lucky_cli/generator_helpers.cr
+++ b/src/lucky_cli/generator_helpers.cr
@@ -39,14 +39,6 @@ module LuckyCli::GeneratorHelpers
     end
   end
 
-  def prepend_text(to, text)
-    within_project do
-      file = File.read(to)
-      updated_file = text + file
-      File.write(to, updated_file)
-    end
-  end
-
   def run_command(command)
     within_project do
       Process.run command,

--- a/src/lucky_cli/generator_helpers.cr
+++ b/src/lucky_cli/generator_helpers.cr
@@ -39,6 +39,14 @@ module LuckyCli::GeneratorHelpers
     end
   end
 
+  def prepend_text(to, text)
+    within_project do
+      file = File.read(to)
+      updated_file = text + file
+      File.write(to, updated_file)
+    end
+  end
+
   def run_command(command)
     within_project do
       Process.run command,

--- a/src/web_app_skeleton/spec/spec_helper.cr
+++ b/src/web_app_skeleton/spec/spec_helper.cr
@@ -1,0 +1,4 @@
+ENV["LUCKY_ENV"] = "test"
+require "spec"
+require "../src/app"
+require "./support/**"


### PR DESCRIPTION
Without explicitly setting the environment to "test" in the spec helper,
its pretty easy to accidentally delete your development database when
cleaning up after running specs.

See issue #100