### PR TITLE
Non-0 exit code when task isn't found

### DIFF
--- a/spec/integration/task_spec.cr
+++ b/spec/integration/task_spec.cr
@@ -1,0 +1,24 @@
+require "../spec_helper"
+
+describe "Running a task" do
+  it "returns a non-zero exit code when running a missing task" do
+    task("missing.task").exit_status.should_not be_successful
+  end
+end
+
+private def run(process)
+  Process.run(
+    process,
+    shell: true,
+    output: true,
+    error: true
+  )
+end
+
+private def task(task_name)
+  run("crystal spec/tasks.cr --no-debug -- #{task_name}")
+end
+
+private def be_successful
+  eq 0
+end

--- a/spec/lucky_cli/runner_spec.cr
+++ b/spec/lucky_cli/runner_spec.cr
@@ -28,9 +28,15 @@ describe LuckyCli::Runner do
   end
 
   it "does not call the task task is not found" do
-    LuckyCli::Runner
-      .run(args: ["not.real"])
-      .should_not have_called_my_cool_task
+    begin
+      LuckyCli::Runner.exit_with_error_if_not_found = false
+
+      LuckyCli::Runner
+        .run(args: ["not.real"])
+        .should_not have_called_my_cool_task
+    ensure
+      LuckyCli::Runner.exit_with_error_if_not_found = true
+    end
   end
 end
 

--- a/spec/tasks.cr
+++ b/spec/tasks.cr
@@ -1,0 +1,8 @@
+require "../lucky_cli"
+
+class PlaceholderTask < LuckyCli::Task
+  def call; end
+  def banner; end
+end
+
+LuckyCli::Runner.run

--- a/src/lucky_cli/runner.cr
+++ b/src/lucky_cli/runner.cr
@@ -3,6 +3,7 @@ require "./text_helpers"
 
 class LuckyCli::Runner
   @@tasks = [] of LuckyCli::Task
+  class_property exit_with_error_if_not_found = true
 
   extend LuckyCli::TextHelpers
 
@@ -26,7 +27,9 @@ class LuckyCli::Runner
         task.call
       else
         TaskNotFoundErrorMessage.print(task_name)
-        exit(127)
+        if (@@exit_with_error_if_not_found)
+          exit(127)
+        end
       end
     end
   end

--- a/src/lucky_cli/runner.cr
+++ b/src/lucky_cli/runner.cr
@@ -26,6 +26,7 @@ class LuckyCli::Runner
         task.call
       else
         TaskNotFoundErrorMessage.print(task_name)
+        exit(127)
       end
     end
   end


### PR DESCRIPTION
Trying to work on #108 but I've been running into trouble. I'm not at all sure my change did the job and I can't figure out how to test it. I've tried a couple things:

First, I tried adding a test to the runner spec, but it seems that if you call `exit` in the src, it will stop the test immediately so you can't actually check anything.

I ended up with another integration spec that creates a whole lucky app, inserts the new and updated cli shard, and tries to run a non-existing task. This generated an error like this:

```shell
Running my.cool_task
Task my.cool_task not found
F

Failures:

  1) Running a task runs an existing task
     Failure/Error: task("my.cool_task").exit_status.should be_not_found

       test-project/node_modules/buffer/test/constructor.js

     # spec/integration/task_spec.cr:17

Finished in 33.82 seconds
1 examples, 1 failures, 0 errors, 0 pending

Failed examples:

crystal spec spec/integration/task_spec.cr:4 # Running a task runs an existing task
```

I can't figure out what's failing here. Eventually, I want to switch this to a minimal "app" that has lucky_cli as its only dependency and a single empty task to test against. I got that working locally, but the exit code wasn't returning 127. So I'm at a bit of a loss.

FWIW, I chose 127 as the exit code because it [commonly means](https://stackoverflow.com/a/1535733/638966) "command not found".

fixes #108