### PR TITLE
Update crystal to 0.24

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -5,7 +5,7 @@ authors:
   - Paul Smith <paulcsmith0218@gmail.com>
 
 
-crystal: 0.20.1
+crystal: 0.24.0
 
 license: MIT
 

--- a/src/lucky_cli/src_template.cr
+++ b/src/lucky_cli/src_template.cr
@@ -1,4 +1,4 @@
-require "secure_random"
+require "random/secure"
 
 class SrcTemplate < Teeplate::FileTree
   directory "#{__DIR__}/../web_app_skeleton"
@@ -10,6 +10,6 @@ class SrcTemplate < Teeplate::FileTree
   end
 
   def secret_key_base
-    SecureRandom.base64(32)
+    Random::Secure.base64(32)
   end
 end


### PR DESCRIPTION
Note: mosop/teeplate also needs updates regarding 0.24 and there is PR already for that

https://github.com/mosop/teeplate/pull/9