### PR TITLE
Allow usage of DATABASE_URL for any environment

### DIFF
--- a/src/web_app_skeleton/config/database.cr.ecr
+++ b/src/web_app_skeleton/config/database.cr.ecr
@@ -1,10 +1,10 @@
 database = "<%= crystal_project_name %>_#{Lucky::Env.name}"
 
 LuckyRecord::Repo.configure do
-  if url = ENV["DATABASE_URL"]?
-    settings.url = url
+  if Lucky::Env.production?
+    settings.url = ENV.fetch("DATABASE_URL")
   else
-    settings.url = LuckyRecord::PostgresURL.build(
+    settings.url = ENV["DATABASE_URL"]? || LuckyRecord::PostgresURL.build(
       hostname: "localhost",
       database: database
     )

--- a/src/web_app_skeleton/config/database.cr.ecr
+++ b/src/web_app_skeleton/config/database.cr.ecr
@@ -1,8 +1,8 @@
 database = "<%= crystal_project_name %>_#{Lucky::Env.name}"
 
 LuckyRecord::Repo.configure do
-  if Lucky::Env.production?
-    settings.url = ENV.fetch("DATABASE_URL")
+  if url = ENV["DATABASE_URL"]?
+    settings.url = url
   else
     settings.url = LuckyRecord::PostgresURL.build(
       hostname: "localhost",


### PR DESCRIPTION
This makes it easier to setup CI configurations that do not
build the 'production' variant.

E.g. on circle ci I think the way to spin up a setup can be achieved like

```yml
version: 2
jobs:
  build:
    docker:
      - image: whatever/myimage
        environment:
          DATABASE_URL: postgres://blog_test_user@127.0.0.1/blog_test
      - image: postgres:9.6.2-alpine
        environment:
          POSTGRES_DB: blog_test
          POSTGRES_USER: blog_test_user
```

which obviously shouldn't do a `production` build, but the default "localhost" doesn't neccessarily apply. Also good for docker-compose stuff, which I guess circle ci uses anyway?