### PR TITLE
Allow tasks to set a custom name

### DIFF
--- a/spec/lucky_cli/runner_spec.cr
+++ b/spec/lucky_cli/runner_spec.cr
@@ -5,7 +5,7 @@ describe LuckyCli::Runner do
     LuckyCli::Runner.tasks.map(&.name).reject(&.==("lucky_cli.dev")).should eq [
       "another_task",
       "my.cool_task",
-      "some.other.task",
+      "my.custom_name",
     ]
   end
 

--- a/spec/lucky_cli/task_spec.cr
+++ b/spec/lucky_cli/task_spec.cr
@@ -5,6 +5,10 @@ describe LuckyCli::Task do
     My::CoolTask.new.name.should eq "my.cool_task"
   end
 
+  it "uses a specified name over the auto generated name" do
+    Some::Other::Task.new.name.should eq "my.custom_name"
+  end
+
   it "creates banner text" do
     My::CoolTask.new.banner.should eq "This task does something awesome"
   end

--- a/spec/support/tasks.cr
+++ b/spec/support/tasks.cr
@@ -8,6 +8,7 @@ end
 
 class Some::Other::Task < LuckyCli::Task
   banner "bar"
+  name "my.custom_name"
 
   def call
   end

--- a/src/lucky_cli/task.cr
+++ b/src/lucky_cli/task.cr
@@ -13,6 +13,18 @@ abstract class LuckyCli::Task
     end
   end
 
+  # Set a custom title for the task
+  #
+  # By default the name is derived from the full module and class name.
+  # However if that name is not desired, a custom one can be set here.
+  # ```
+  # class Dev::Prime < LuckyCli::Task
+  #   name "Development database primer"
+  #   banner "Seed the development database with example data"
+  #
+  #   # other methods, etc.
+  # end
+  # ```
   macro name(name_text)
     def name
       {{name_text}}

--- a/src/lucky_cli/task.cr
+++ b/src/lucky_cli/task.cr
@@ -13,6 +13,12 @@ abstract class LuckyCli::Task
     end
   end
 
+  macro name(name_text)
+    def name
+      {{name_text}}
+    end
+  end
+
   abstract def call
   abstract def banner
 end


### PR DESCRIPTION
If no name is set, it defaults to inferring the name as it does now: by downcasing and replacing the namespace colons with a period.

The two `name` methods inside of `LukcyCLI::Task` strikes me as a little odd, but it does work. I'm not exactly sure how Crystal handles with one to pick. Maybe last implementation wins? Either way I couldn't figure out how to combine them into one method. I needed some way to generate a default name if nothing was specified, but override it with this custom one if it exists, and this is only specified through being inherited.

I also had `abstract def call` in here at one point but it's not needed currently because being inherited always generates the name method, even if you then later pass a custom name in yourself.

fixes #138 