### PR TITLE
Include the responsive_meta_tag by default in the main layout

### DIFF
--- a/src/web_app_skeleton/src/pages/main_layout.cr
+++ b/src/web_app_skeleton/src/pages/main_layout.cr
@@ -20,6 +20,7 @@ abstract class MainLayout
         css_link asset("css/app.css")
         js_link asset("js/app.js")
         csrf_meta_tags
+        responsive_meta_tag
       end
 
       body do


### PR DESCRIPTION
The MainLayout should include the responsive meta tag by default. 

See: https://github.com/luckyframework/lucky/issues/320