### PR TITLE
Run precompiled tasks if available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 /doc/
 /libs/
 /lib/
-/bin/
+/bin/generate_test_project
+/bin/*.dwarf
 /.shards/
 lucky
 /test-project/

--- a/spec/integration/task_spec.cr
+++ b/spec/integration/task_spec.cr
@@ -4,13 +4,21 @@ describe "Running a task" do
   it "returns a non-zero exit code when running a missing task" do
     task("missing.task").exit_status.should_not be_successful
   end
+
+  it "runs precompiled tasks" do
+    io = IO::Memory.new
+
+    run("crystal src/lucky.cr precompiled_task", output: io)
+
+    io.to_s.should eq "Ran precompiled task\n"
+  end
 end
 
-private def run(process)
+private def run(process, output = STDOUT)
   Process.run(
     process,
     shell: true,
-    output: STDOUT,
+    output: output,
     error: STDERR
   )
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,3 +1,19 @@
 require "spec"
+require "file_utils"
 require "../src/lucky_cli"
 require "./support/**"
+
+FileUtils.mkdir_p("bin/lucky")
+
+if !setup_precompiled_task.success?
+  raise "Failed to setup precompiled task"
+end
+
+private def setup_precompiled_task
+  Process.run(
+    "crystal build spec/support/precompiled_task.cr -o bin/lucky/precompiled_task",
+    shell: true,
+    output: IO::Memory.new,
+    error: STDERR
+  )
+end

--- a/spec/support/precompiled_task.cr
+++ b/spec/support/precompiled_task.cr
@@ -1,0 +1,1 @@
+puts "Ran precompiled task"

--- a/src/generators/web.cr
+++ b/src/generators/web.cr
@@ -54,6 +54,7 @@ class LuckyCli::Generators::Web
     /node_modules
     yarn-error.log
     /public/
+    /bin/lucky/
     server
     *.dwarf
     *.local.cr

--- a/src/lucky.cr
+++ b/src/lucky.cr
@@ -8,10 +8,25 @@ include LuckyCli::TextHelpers
 
 args = ARGV.join(" ")
 
-if ARGV.first? == "dev"
+private def task_name : String?
+  ARGV.first?
+end
+
+private def task_precompiled? : Bool
+  !task_name.nil? && File.exists?("bin/lucky/#{task_name}")
+end
+
+if task_name == "dev"
   LuckyCli::Dev.new.call
-elsif ARGV.first? == "ensure_process_runner_installed"
+elsif task_name == "ensure_process_runner_installed"
   LuckyCli::EnsureProcessRunnerInstalled.new.call
+elsif task_precompiled?
+  exit Process.run(
+    "bin/lucky/#{task_name}",
+    shell: true,
+    output: STDOUT,
+    error: STDERR
+  ).exit_status
 elsif File.exists?("./tasks.cr")
   exit Process.run(
     "crystal run ./tasks.cr -- #{args}",
@@ -19,9 +34,9 @@ elsif File.exists?("./tasks.cr")
     output: STDOUT,
     error: STDERR
   ).exit_status
-elsif ARGV.first? == "init"
+elsif task_name == "init"
   LuckyCli::InitQuestions.run
-elsif ["-v", "--version"].includes?(ARGV.first?)
+elsif ["-v", "--version"].includes?(task_name)
   puts LuckyCli::VERSION
 else
   puts <<-MISSING_TASKS_FILE


### PR DESCRIPTION
This will allow tasks to be precompiled and run with zero latency. This
will be great for watch tasks, generators, or anything that doesn't rely
on application code that changes often. So things like migrations,
routes, etc.