### PR TITLE
Configure process runner to use STDIN

### DIFF
--- a/spec/integration/task_spec.cr
+++ b/spec/integration/task_spec.cr
@@ -12,6 +12,14 @@ describe "Running a task" do
 
     io.to_s.should eq "Ran precompiled task\n"
   end
+
+  it "allows tasks to accept input from STDIN" do
+    io = IO::Memory.new
+
+    run("echo 'hello world' | LUCKY_TASKS_FILE=./spec/tasks.cr crystal src/lucky.cr -- task_with_input", output: io)
+
+    io.to_s.should eq "input: hello world\n"
+  end
 end
 
 private def run(process, output = STDOUT)

--- a/spec/tasks.cr
+++ b/spec/tasks.cr
@@ -6,4 +6,13 @@ class PlaceholderTask < LuckyCli::Task
   def banner; end
 end
 
+class TaskWithInput < LuckyCli::Task
+  banner "this should be first"
+
+  def call
+    input = gets
+    puts "input: #{input}"
+  end
+end
+
 LuckyCli::Runner.run

--- a/src/lucky.cr
+++ b/src/lucky.cr
@@ -7,6 +7,7 @@ require "./ensure_process_runner_installed"
 include LuckyCli::TextHelpers
 
 args = ARGV.join(" ")
+tasks_file = ENV.fetch("LUCKY_TASKS_FILE", "./tasks.cr")
 
 private def task_name : String?
   ARGV.first?
@@ -35,9 +36,9 @@ elsif task_precompiled?
     output: STDOUT,
     error: STDERR
   ).exit_status
-elsif File.exists?("./tasks.cr")
+elsif File.exists?(tasks_file)
   exit Process.run(
-    "crystal run ./tasks.cr -- #{args}",
+    "crystal run #{tasks_file} -- #{args}",
     shell: true,
     input: STDIN,
     output: STDOUT,

--- a/src/lucky.cr
+++ b/src/lucky.cr
@@ -31,6 +31,7 @@ elsif task_precompiled?
   exit Process.run(
     "#{precompiled_task_path.not_nil!} #{ARGV.skip(1).join(" ")}",
     shell: true,
+    input: STDIN,
     output: STDOUT,
     error: STDERR
   ).exit_status
@@ -38,6 +39,7 @@ elsif File.exists?("./tasks.cr")
   exit Process.run(
     "crystal run ./tasks.cr -- #{args}",
     shell: true,
+    input: STDIN,
     output: STDOUT,
     error: STDERR
   ).exit_status


### PR DESCRIPTION
- [x] Add test

When wanting to use `gets` or `read_line`, the task would immediately
return without accepting input. That is because `Process.run` is
configured to use `Redirect::Close`. We can configure it to accept STDIN
instead.
[Docs for Process.run](https://crystal-lang.org/api/0.24.1/Process.html#run%28command%3AString%2Cargs%3Dnil%2Cenv%3AEnv%3Dnil%2Cclear_env%3ABool%3Dfalse%2Cshell%3ABool%3Dfalse%2Cinput%3AStdio%3DRedirect%3A%3AClose%2Coutput%3AStdio%3DRedirect%3A%3AClose%2Cerror%3AStdio%3DRedirect%3A%3AClose%2Cchdir%3AString%3F%3Dnil%29%3AProcess%3A%3AStatus-class-method)

Closes #178 