### PR TITLE
Enable backslash escapes in `bin/setup`

### DIFF
--- a/src/web_app_skeleton/bin/setup.ecr
+++ b/src/web_app_skeleton/bin/setup.ecr
@@ -16,31 +16,31 @@ if ! command -v yarn > /dev/null; then
   exit 1
 fi
 
-echo "\n▸ Installing node dependencies"
+echo -e "\n▸ Installing node dependencies"
 yarn install --silent | indent
 
-echo "\n▸ Compiling assets"
+echo -e "\n▸ Compiling assets"
 yarn dev | indent
 
 <%- end -%>
-echo "\n▸ Installing shards"
+echo -e "\n▸ Installing shards"
 crystal deps | indent
 
-echo "\n▸ Checking that a process runner is installed"
+echo -e "\n▸ Checking that a process runner is installed"
 # Only if this isn't CI
 if [ -z "$CI" ]; then
   lucky ensure_process_runner_installed
 fi
 echo "✔ Done" | indent
 
-echo "\n▸ Setting up the database"
+echo -e "\n▸ Setting up the database"
 lucky db.create | indent
 
-echo "\n▸ Migrating the database"
+echo -e "\n▸ Migrating the database"
 lucky db.migrate | indent
 
-echo "\n▸ Seed the database with required and sample records"
+echo -e "\n▸ Seed the database with required and sample records"
 lucky db.required_seeds | indent
 lucky db.helpful_seeds | indent
 
-echo "\n✔ All done. Run 'lucky dev' to start the app"
+echo -e "\n✔ All done. Run 'lucky dev' to start the app"


### PR DESCRIPTION
On some platforms `\n` newlines are printed literally by echo. To
prevent this, `echo` needs to be called with the `-e` option.

Fixes #189