### PR TITLE
Correct usage of the shared field component

### DIFF
--- a/src/browser_app_skeleton/src/components/shared/field.cr
+++ b/src/browser_app_skeleton/src/components/shared/field.cr
@@ -4,8 +4,8 @@ module Shared::Field
   #
   # ## Usage
   #
-  #     render_field(form.email) { |i| email_input i }
-  #     render_field(form.email) { |i| email_input i, autofocus: "true" }
+  #     field(form.email) { |i| email_input i }
+  #     field(form.email) { |i| email_input i, autofocus: "true" }
   #
   # ## Customization
   #


### PR DESCRIPTION
Usage is showing `render_field` while the method is called `field`.