### PR TITLE
Update crystal to 0.25.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -4,11 +4,11 @@ version: 0.10.0
 authors:
   - Paul Smith <paulcsmith0218@gmail.com>
 
-crystal: 0.24.1
+crystal: 0.25.0
 
 license: MIT
 
 dependencies:
   teeplate:
     github: bcardiff/teeplate
-    branch: crystal/v0.24.0
+    branch: crystal/v0.25.0


### PR DESCRIPTION
Note: in mosop/teeplate the changes for 0.24 hasn't been merged

The [PR in mosop/teeplate](https://github.com/mosop/teeplate/pull/12) to update to 0.25.0 could serve as a discussion to avoid depending on my forks branch

Note: In `src/generators/web.cr` an updated version of lucky and lucky_migrator are also needed for proper crystal 0.25 support.