### PR TITLE
Remove console clearing from webpack mix

### DIFF
--- a/src/browser_app_skeleton/webpack.mix.js
+++ b/src/browser_app_skeleton/webpack.mix.js
@@ -24,7 +24,9 @@ mix
     postCss: [require("lost")],
     // If you want to process images, change this to true and add options from
     // https://github.com/tcoopman/image-webpack-loader
-    imgLoaderOptions: { enabled: false }
+    imgLoaderOptions: { enabled: false },
+    // Stops Mix from clearing the console when compilation succeeds
+    clearConsole: false
   })
   // Set public path so manifest gets output here
   .setPublicPath("public")


### PR DESCRIPTION
Previously webpack mix would clear the console output on successful
compilation. Adding `clearConsole: false` will stop that behavior. This
will make it easier to tell when there is an error with Crystal
compilation because it won't be pushed away.