### PR TITLE
added linebreak at the end of text when appending to a file. Fixes #224

### DIFF
--- a/src/lucky_cli/generator_helpers.cr
+++ b/src/lucky_cli/generator_helpers.cr
@@ -34,7 +34,7 @@ module LuckyCli::GeneratorHelpers
   def append_text(to, text)
     within_project do
       file = File.read(to)
-      updated_file = file + text
+      updated_file = file + text + "\n"
       File.write(to, updated_file)
     end
   end


### PR DESCRIPTION
This fixes [this thing](https://github.com/luckyframework/lucky_cli/blob/master/src/generators/web.cr#L75) so the public/js will end up on the next line.