### PR TITLE
Run Heroku specs based on ENV var

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ You can see all available tasks by running `lucky --help`
 1.  Create your feature branch (git checkout -b my-new-feature)
 1.  [Install the required dependencies](https://luckyframework.org/guides/installing.html#install-required-dependencies
 1.  Make sure specs pass: `crystal spec`
+1.  To specs that deploy a sample app to Heroku, run `RUN_HEROKU_SPECS=1 crystal spec`. Make sure you've setup Heroku CLI locally first.
 1.  Commit your changes (git commit -am 'Add some feature')
 1.  Push to the branch (git push origin my-new-feature)
 1.  Create a new Pull Request

--- a/spec/integration/deploy_to_heroku_spec.cr
+++ b/spec/integration/deploy_to_heroku_spec.cr
@@ -1,6 +1,6 @@
 require "../spec_helper"
 
-{% if flag?("run-deploy-specs") %}
+{% if env("RUN_HEROKU_SPECS") %}
   include ShouldRunSuccessfully
 
   Spec.before_each do


### PR DESCRIPTION
* The Problem

External contributions that run on Travis CI don't have access to the
encrypted ENV vars. So when the Heroku deploy specs ran they failed
because the HEROKU_API_KEY and HEROKU_EMAIL were not set.

* The solution

Run Heroku specs based on the HEROKU_RUN_SPECS env variable. Then in
Travis set an encrypted HEROKU_RUN_SPECS variable. That way it is not
set for external contributions and the Heroku specs are skipped. This
should work fine since generally the Heroku specs work. They will run
whenever a new version is created since that will always be down by
someone with repo write/read access.