### PR TITLE
Sanitize name in lucky init

### DIFF
--- a/spec/integration/init_web_spec.cr
+++ b/spec/integration/init_web_spec.cr
@@ -68,6 +68,30 @@ describe "Initializing a new web project" do
     message = "Folder named test-project already exists, please use a different name"
     output.to_s.strip.should contain(message)
   end
+
+  it "does not create project if project name is not a valid project name" do
+    output = IO::Memory.new
+    Process.run(
+      "crystal src/lucky.cr init 'test project'",
+      output: output,
+      shell: true
+    )
+    message = "Project name should only contain letters, numbers, underscores, and dashes."
+    output.to_s.strip.should contain(message)
+  end
+
+  it "translates dashes to underscores in the project name" do
+    output = IO::Memory.new
+    Process.run(
+      "crystal src/lucky.cr init 'test-project'",
+      output: output,
+      shell: true
+    )
+
+    shard_yml_name = File.read_lines("test-project/shard.yml").select { |line| line =~ /^name:/ }.first
+    shard_yml_name.should eq("name: test_project")
+    File.exists?("test-project/src/test_project.cr").should be_true
+  end
 end
 
 private def compile_and_run_specs_on_test_project

--- a/spec/lucky_cli/generators/validators_spec.cr
+++ b/spec/lucky_cli/generators/validators_spec.cr
@@ -1,0 +1,37 @@
+require "../../spec_helper"
+
+private def validate(string)
+  LuckyCli::Generators::Validators::ProjectName.valid? string
+end
+
+private def sanitize(string)
+  LuckyCli::Generators::Validators::ProjectName.sanitize string
+end
+
+describe LuckyCli::Generators::Validators::ProjectName do
+  hyphenate = "sector-seven"
+  special_characters = "this string is emphatic"
+  title = "From the Earth to the Moon"
+
+  it "doesn't allow special characters" do
+    validate(special_characters).should be_false
+  end
+
+  it "corrects special characters" do
+    expected = "this_string_is_emphatic"
+    sanitize(special_characters).should eq expected
+  end
+
+  it "allows hyphens" do
+    validate(hyphenate).should be_true
+  end
+
+  it "doesn't allow uppercase characters" do
+    validate(title).should be_false
+  end
+
+  it "corrects uppercase characters" do
+    expected = "from_the_earth_to_the_moon"
+    sanitize(title).should eq expected
+  end
+end

--- a/src/generators/validators.cr
+++ b/src/generators/validators.cr
@@ -1,0 +1,11 @@
+module LuckyCli::Generators::Validators::ProjectName
+  extend self
+
+  def sanitize(name)
+    name.downcase.gsub(/[^a-z0-9_-]/, "_").strip('_')
+  end
+
+  def valid?(name)
+    sanitize(name) == name
+  end
+end

--- a/src/generators/web.cr
+++ b/src/generators/web.cr
@@ -10,8 +10,11 @@ class LuckyCli::Generators::Web
     project_name : String,
     @options : Options
   )
-    @project_dir = project_name.gsub(" ", "_")
-    @project_name = @project_dir.gsub("-", "_")
+    @project_dir = project_name
+    @project_name = project_name.gsub('-', '_')
+
+    validate_project_name @project_name
+
     @template_dir = File.join(__DIR__, "templates")
   end
 
@@ -177,6 +180,19 @@ class LuckyCli::Generators::Web
   private def ensure_directory_does_not_exist
     if Dir.exists?("./#{project_dir}")
       puts "Folder named #{project_dir} already exists, please use a different name".colorize.red.bold
+      exit
+    end
+  end
+
+  private def validate_project_name(name)
+    unless Validators::ProjectName.valid?(name)
+      message = <<-TEXT
+      Project name should only contain letters, numbers, underscores, and dashes.
+
+      How about: lucky init '#{Validators::ProjectName.sanitize(name)}'?
+      TEXT
+
+      puts message.colorize(:red)
       exit
     end
   end


### PR DESCRIPTION
fixes #248 

Quick and simple fix for #248. There could probably be a _little_ more logic here, but I'm not sure what that'd include. Since I don't see Lucky building any class names with the project name, I think this is fine.

It may be worth collapsing multiple `_`s.

The distinction between `@project_name` and `@project_dir` may be unnecessary now, or I may be incorrect in making them the same.

This sort of thing is difficult write tests for, but here's what I did in the terminal. Minimally edited to protect the name of the innocent computer :P

```text
> rm -r yolo; lucky_cli/bin/lucky init Yolo/; ag -i yolo yolo
Done generating your Lucky project

  ▸ cd into yolo
  ▸ check database settings in config/database.cr
  ▸ run bin/setup
  ▸ run lucky dev to start the server
yolo/config/database.cr
1:database = "yolo_#{Lucky::Env.name}"

yolo/config/session.cr
4:  settings.key = "yolo"

yolo/shard.yml
1:name: yolo
8:  yolo:
9:    main: src/yolo.cr

yolo/README.md
1:# yolo

##########################################################################
> rm -r yolo; lucky_cli/bin/lucky init Yolo/////; ag -i yolo yolo/
Done generating your Lucky project

  ▸ cd into yolo
  ▸ check database settings in config/database.cr
  ▸ run bin/setup
  ▸ run lucky dev to start the server
yolo/config/database.cr
1:database = "yolo_#{Lucky::Env.name}"

yolo/config/session.cr
4:  settings.key = "yolo"

yolo/shard.yml
1:name: yolo
8:  yolo:
9:    main: src/yolo.cr

yolo/README.md
1:# yolo

##########################################################################
> rm -r yolo; lucky_cli/bin/lucky init Yolo/////; ag -i yolo 
Done generating your Lucky project

  ▸ cd into yolo
  ▸ check database settings in config/database.cr
  ▸ run bin/setup
  ▸ run lucky dev to start the server
yolo/config/database.cr
1:database = "yolo_#{Lucky::Env.name}"

yolo/config/session.cr
4:  settings.key = "yolo"

yolo/shard.yml
1:name: yolo
8:  yolo:
9:    main: src/yolo.cr

yolo/README.md
1:# yolo

##########################################################################
> rm -r yolo; lucky_cli/bin/lucky init 'Yol\(\*&\(\*&o/////'; ag -i yolo 
Done generating your Lucky project

  ▸ cd into yol__________o
  ▸ check database settings in config/database.cr
  ▸ run bin/setup
  ▸ run lucky dev to start the server

> ag -i yol
yol__________o/config/database.cr
1:database = "yol__________o_#{Lucky::Env.name}"

yol__________o/config/session.cr
4:  settings.key = "yol__________o"

yol__________o/shard.yml
1:name: yol__________o
8:  yol__________o:
9:    main: src/yol__________o.cr

yol__________o/README.md
1:# yol__________o

##########################################################################
> rm -r yolo; lucky_cli/bin/lucky init 'Yol23/'; ag -i yolo 
rm: yolo: No such file or directory
Done generating your Lucky project

  ▸ cd into yol23
  ▸ check database settings in config/database.cr
  ▸ run bin/setup
  ▸ run lucky dev to start the server

> ag yol23
yol23/config/database.cr
1:database = "yol23_#{Lucky::Env.name}"

yol23/config/session.cr
4:  settings.key = "yol23"

yol23/shard.yml
1:name: yol23
8:  yol23:
9:    main: src/yol23.cr

yol23/README.md
1:# yol23
```