### PR TITLE
Fix naming of generated spec method

### DIFF
--- a/src/browser_authentication_app_skeleton/spec/flows/authentication_spec.cr
+++ b/src/browser_authentication_app_skeleton/spec/flows/authentication_spec.cr
@@ -22,10 +22,10 @@ describe "Authentication flow" do
     flow = BaseFlow.new
 
     flow.visit Me::Show, as: user
-    should_be_signed_out(flow)
+    should_be_signed_in(flow)
   end
 end
 
-private def should_be_signed_out(flow)
+private def should_be_signed_in(flow)
   flow.el("@sign-out-button").should be_on_page
 end


### PR DESCRIPTION
Previously, the test was asserting that a user that has signed in via
the backdoor auth flow was signed *out*.

Don't think this needs an additional test, but let me know if one can be made.

Thanks for all your work on this framework! So excited about its future 😄 