### PR TITLE
Update templates for new lucky cookies

### DIFF
--- a/src/browser_authentication_app_skeleton/src/actions/mixins/password_resets/require_token.cr
+++ b/src/browser_authentication_app_skeleton/src/actions/mixins/password_resets/require_token.cr
@@ -10,7 +10,7 @@ module Auth::PasswordResets::RequireToken
     if Authentic.valid_password_reset_token?(user, token)
       continue
     else
-      flash.danger = "The password reset link is incorrect or expired. Please try again."
+      flash.failure = "The password reset link is incorrect or expired. Please try again."
       redirect to: PasswordResetRequests::New
     end
   end

--- a/src/browser_authentication_app_skeleton/src/actions/mixins/password_resets/token_from_session.cr
+++ b/src/browser_authentication_app_skeleton/src/actions/mixins/password_resets/token_from_session.cr
@@ -1,5 +1,5 @@
 module Auth::PasswordResets::TokenFromSession
   private def token : String
-    session[:password_reset_token] || raise "Password reset token not found in session"
+    session.get?(:password_reset_token) || raise "Password reset token not found in session"
   end
 end

--- a/src/browser_authentication_app_skeleton/src/actions/password_resets/create.cr
+++ b/src/browser_authentication_app_skeleton/src/actions/password_resets/create.cr
@@ -5,7 +5,7 @@ class PasswordResets::Create < BrowserAction
   post "/password_resets/:user_id" do
     PasswordResetForm.update(user, params) do |form, user|
       if form.saved?
-        session.delete(:password_reset_token)
+        session.unset(:password_reset_token)
         sign_in user
         flash.success = "Your password has been reset"
         redirect to: Home::Index

--- a/src/browser_authentication_app_skeleton/src/actions/password_resets/new.cr
+++ b/src/browser_authentication_app_skeleton/src/actions/password_resets/new.cr
@@ -15,6 +15,6 @@ class PasswordResets::New < BrowserAction
   end
 
   private def make_token_available_to_future_actions
-    session[:password_reset_token] = token
+    session.set(:password_reset_token, token)
   end
 end

--- a/src/browser_authentication_app_skeleton/src/actions/sign_ins/create.cr
+++ b/src/browser_authentication_app_skeleton/src/actions/sign_ins/create.cr
@@ -8,7 +8,7 @@ class SignIns::Create < BrowserAction
         flash.success = "You're now signed in"
         Authentic.redirect_to_originally_requested_path(self, fallback: Home::Index)
       else
-        flash.danger = "Sign in failed"
+        flash.failure = "Sign in failed"
         render NewPage, form: form
       end
     end

--- a/src/web_app_skeleton/config/cookies.cr.ecr
+++ b/src/web_app_skeleton/config/cookies.cr.ecr
@@ -1,0 +1,7 @@
+Lucky::SessionCookie.configure do |settings|
+  settings.key = "_<%= crystal_project_name %>_session"
+end
+
+Lucky::CookieJar.configure do |settings|
+  settings.default_expiration = 1.year
+end

--- a/src/web_app_skeleton/config/session.cr.ecr
+++ b/src/web_app_skeleton/config/session.cr.ecr
@@ -1,6 +1,0 @@
-require "./server"
-
-Lucky::Session::Store.configure do |settings|
-  settings.key = "<%= crystal_project_name %>"
-  settings.secret = Lucky::Server.settings.secret_key_base
-end

--- a/src/web_app_skeleton/src/app.cr.ecr
+++ b/src/web_app_skeleton/src/app.cr.ecr
@@ -29,11 +29,11 @@ class App
       Lucky::LogHandler.new,
       <%- if browser? -%>
       Lucky::SessionHandler.new,
-      Lucky::Flash::Handler.new,
+      Lucky::FlashHandler.new,
       <%- else %>
       # Disabled in API mode, but can be enabled if you need them:
       # Lucky::SessionHandler.new,
-      # Lucky::Flash::Handler.new,
+      # Lucky::FlashHandler.new,
       <%- end -%>
       Lucky::ErrorHandler.new(action: Errors::Show),
       Lucky::RouteHandler.new,


### PR DESCRIPTION
Including:

Cookie/Session accessing with .get and .get?
Cookie/Session setting with .set
Cookie removal with .expire
Session key removal with .unset
Flash.danger -> failure
Updating the FlashHandler
Updating the habitat settings for a new Lucky app including
Lucky::SessionCookie.key and Lucky::CookieJar.default_expiration
Removing old habitat settings (Lucky::Session::Store)

This relates to https://github.com/luckyframework/lucky/pull/609

*Note also:* That these tests will fail because they point to the master branch of Lucky. Once that's merged, these tests should pass.