### PR TITLE
Adding 0 byte default favicon to generated web app

### DIFF
--- a/spec/integration/init_web_spec.cr
+++ b/spec/integration/init_web_spec.cr
@@ -14,6 +14,7 @@ describe "Initializing a new web project" do
     compile_and_run_specs_on_test_project
     File.read("test-project/.travis.yml").should contain "postgresql"
     File.read("test-project/public/mix-manifest.json").should contain "images/cat.gif"
+    File.exists?("test-project/public/favicon.ico").should eq true
   end
 
   it "creates a full web app with generator" do


### PR DESCRIPTION
This fixes https://github.com/luckyframework/lucky/issues/646

Right now a default generated lucky app will throw 500s in development when the browser auto-requests the favicon (404 in production). This just adds a blank default one so the file exists. The developer can change it out when they want.