### PR TITLE
Add default blank .env file to generated project. fixes #75

### DIFF
--- a/spec/integration/init_web_spec.cr
+++ b/spec/integration/init_web_spec.cr
@@ -15,6 +15,7 @@ describe "Initializing a new web project" do
     File.read("test-project/.travis.yml").should contain "postgresql"
     File.read("test-project/public/mix-manifest.json").should contain "images/cat.gif"
     File.exists?("test-project/public/favicon.ico").should eq true
+    File.exists?("test-project/.env").should eq true
   end
 
   it "creates a full web app with generator" do

--- a/src/generators/web.cr
+++ b/src/generators/web.cr
@@ -74,6 +74,7 @@ class LuckyCli::Generators::Web
     server
     *.dwarf
     *.local.cr
+    .env
     TEXT
     if browser?
       append_text to: ".gitignore", text: <<-TEXT


### PR DESCRIPTION
This add an empty `.env` file which is ignored by default. 