### PR TITLE
Trapping exit should go before listen

### DIFF
--- a/src/web_app_skeleton/src/server.cr
+++ b/src/web_app_skeleton/src/server.cr
@@ -7,8 +7,9 @@ Habitat.raise_if_missing_settings!
 
 app = App.new
 puts "Listening on #{app.base_uri}"
-app.listen
 
 Signal::INT.trap do
   app.close
 end
+
+app.listen


### PR DESCRIPTION
The problem was that `app.listen` halts execution, so we never actually trapped
the exit. Now we tell Crystal to trap the exit *before* listening. That way if you ctrl-c 
it will terminate as expected.