### PR TITLE
Remove confusing port output when proxied

### DIFF
--- a/src/lucky_cli/src_template.cr
+++ b/src/lucky_cli/src_template.cr
@@ -12,6 +12,10 @@ class SrcTemplate < Teeplate::FileTree
     @crystal_project_name = @project_name.gsub("-", "_")
   end
 
+  def proxied_through_browsersync?
+    browser?
+  end
+
   private def browser?
     !api_only?
   end

--- a/src/web_app_skeleton/src/server.cr.ecr
+++ b/src/web_app_skeleton/src/server.cr.ecr
@@ -6,7 +6,9 @@ end
 Habitat.raise_if_missing_settings!
 
 app = App.new
+<%- if !proxied_through_browsersync? -%>
 puts "Listening on #{app.base_uri}"
+<%- end -%>
 
 Signal::INT.trap do
   app.close


### PR DESCRIPTION
Full API apps use Browsersync. Outputting the original port
makes it hard to tell which one to use. Instead, use the one from
Browsersync