### PR TITLE
Make it clear backdoor is in test only

### DIFF
--- a/src/base_authentication_app_skeleton/src/actions/mixins/auth/test_backdoor.cr
+++ b/src/base_authentication_app_skeleton/src/actions/mixins/auth/test_backdoor.cr
@@ -1,9 +1,9 @@
-module Auth::SignInThroughBackdoor
+module Auth::TestBackdoor
   macro included
-    before sign_in_through_backdoor
+    before test_backdoor
   end
 
-  private def sign_in_through_backdoor
+  private def test_backdoor
     if Lucky::Env.test? && (user_id = params.get?(:backdoor_user_id))
       user = UserQuery.find(user_id)
       sign_in user

--- a/src/browser_app_skeleton/src/actions/browser_action.cr.ecr
+++ b/src/browser_app_skeleton/src/actions/browser_action.cr.ecr
@@ -7,7 +7,7 @@ abstract class BrowserAction < Lucky::Action
   # When testing you can skip normal sign in by using `visit` with the `as` param
   #
   # flow.visit Me::Show, as: UserBox.create
-  include Auth::SignInThroughBackdoor
+  include Auth::TestBackdoor
 
   # By default all actions require sign in, unless you use the
   # `Auth::SkipRequireSignIn` module in `src/mixins/auth/skip_require_sign_in.cr`


### PR DESCRIPTION
It was scary to see "sign_in_through_backdoor" in your logs.

This name change makes things shorter and also clarifies that the
backdoor is for testing only.