### PR TITLE
Added 2 methods to app which will become abstract methods in BaseApp

### DIFF
--- a/src/web_app_skeleton/src/app.cr.ecr
+++ b/src/web_app_skeleton/src/app.cr.ecr
@@ -50,4 +50,13 @@ class App < Lucky::BaseApp
       Lucky::RouteNotFoundHandler.new,
     ]
   end
+
+  def protocol
+    "http"
+  end
+
+  def listen
+    server.bind_tcp(host, port, false)
+    server.listen
+  end
 end

--- a/src/web_app_skeleton/src/app.cr.ecr
+++ b/src/web_app_skeleton/src/app.cr.ecr
@@ -56,7 +56,8 @@ class App < Lucky::BaseApp
   end
 
   def listen
-    server.bind_tcp(host, port, false)
+    # https://crystal-lang.org/api/0.27.2/HTTP/Server.html#bind_tcp%28host%3AString%2Cport%3AInt32%2Creuse_port%3ABool%3Dfalse%29%3ASocket%3A%3AIPAddress-instance-method
+    server.bind_tcp(host, port, reuse_port: false)
     server.listen
   end
 end


### PR DESCRIPTION
Per [this conversation](https://github.com/luckyframework/lucky/issues/707), these two methods will become abstract on the parent class. This allows the dev to quickly customize if need be once the app is generated. 

Also, I added the 3rd argument of false since false is already the default. This gives a quick insight in to being able to set it to true. I think I want to add a comment on here too, but wording was weird. 

> The third argument disabled the SO_REUSEPORT option

If you have an idea, let me know.