### PR TITLE
Rename /dependencies to /shards

### DIFF
--- a/src/web_app_skeleton/src/app.cr.ecr
+++ b/src/web_app_skeleton/src/app.cr.ecr
@@ -1,4 +1,4 @@
-require "./dependencies"
+require "./shards"
 
 # Load .env file before any other config or app code
 Dotenv.load

--- a/src/web_app_skeleton/src/shards.cr
+++ b/src/web_app_skeleton/src/shards.cr
@@ -1,3 +1,4 @@
+# Require your shards here
 require "dotenv"
 require "avram"
 require "lucky"


### PR DESCRIPTION
That's what Crystal calls them and that's what we should too. Also
clarifies that this is just for loading shards.