### PR TITLE
disable colorize output for production by default. 

### DIFF
--- a/src/web_app_skeleton/config/color.cr
+++ b/src/web_app_skeleton/config/color.cr
@@ -1,0 +1,4 @@
+# This enables the color output when in development
+# Check out the Colorize docs for more information
+# https://crystal-lang.org/api/Colorize.html
+Colorize.enabled = Lucky::Env.development?

--- a/src/web_app_skeleton/config/color.cr
+++ b/src/web_app_skeleton/config/color.cr
@@ -1,4 +1,0 @@
-# This enables the color output when in development
-# Check out the Colorize docs for more information
-# https://crystal-lang.org/api/Colorize.html
-Colorize.enabled = Lucky::Env.development?

--- a/src/web_app_skeleton/config/logger.cr
+++ b/src/web_app_skeleton/config/logger.cr
@@ -1,5 +1,10 @@
 require "file_utils"
 
+# This enables the color output when in development
+# Check out the Colorize docs for more information
+# https://crystal-lang.org/api/Colorize.html
+Colorize.enabled = Lucky::Env.development?
+
 logger =
   if Lucky::Env.test?
     # Logs to `tmp/test.log` so you can see what's happening without having


### PR DESCRIPTION
Fixes #317 

I'm wondering if this might go better in the logger.cr file that already exists since this is more related to logging? 