### PR TITLE
When in api_only, skip rendering exception page on errors. 

### DIFF
--- a/src/web_app_skeleton/src/actions/errors/show.cr.ecr
+++ b/src/web_app_skeleton/src/actions/errors/show.cr.ecr
@@ -29,7 +29,9 @@ class Errors::Show < Lucky::ErrorAction
   # This is the catch all method that renders unhandled exceptions
   def handle_error(error : Exception)
     Lucky.logger.error(unhandled_error: error.inspect_with_backtrace)
-
+    <%- if api_only? -%>
+    render_unhandled_error(error)
+    <%- else -%>
     if Lucky::ErrorHandler.settings.show_debug_output
       # In development and test, render a debug page
       render_detailed_exception_page(error)
@@ -37,6 +39,7 @@ class Errors::Show < Lucky::ErrorAction
       # Otherwise render a nice looking error for users
       render_unhandled_error(error)
     end
+    <%- end -%>
   end
 
   private def render_detailed_exception_page(error)


### PR DESCRIPTION
Fixes #321 

I took a stab at this. Not sure if this is what you were going for, but it made sense to me. Skip calling the render exception page if it's api_only.