### PR TITLE
Changed from 'letters' to 'lowercase letters' to match the validation

### DIFF
--- a/spec/integration/init_web_spec.cr
+++ b/spec/integration/init_web_spec.cr
@@ -93,7 +93,7 @@ describe "Initializing a new web project" do
         output: output,
         shell: true
       )
-      message = "Project name should only contain letters, numbers, underscores, and dashes."
+      message = "Project name should only contain lowercase letters, numbers, underscores, and dashes."
       output.to_s.strip.should contain(message)
     end
   end

--- a/src/generators/web.cr
+++ b/src/generators/web.cr
@@ -180,7 +180,7 @@ class LuckyCli::Generators::Web
   private def validate_project_name(name)
     unless Validators::ProjectName.valid?(name)
       message = <<-TEXT
-      Project name should only contain letters, numbers, underscores, and dashes.
+      Project name should only contain lowercase letters, numbers, underscores, and dashes.
 
       How about: lucky init '#{Validators::ProjectName.sanitize(name)}'?
       TEXT


### PR DESCRIPTION
Small but confusing if I try to create a project named "Bananas" and get told it doesn't work.

Unless it's the validation that needs to be changed, which would be as simple as modifying the regex in to include uppercase.