### PR TITLE
Remove Browsersync UI and make comments concise

### DIFF
--- a/src/web_app_skeleton/bs-config.js
+++ b/src/web_app_skeleton/bs-config.js
@@ -1,14 +1,8 @@
 /*
- |--------------------------------------------------------------------------
  | Browser-sync config file
- |--------------------------------------------------------------------------
  |
  | For up-to-date information about the options:
  |   http://www.browsersync.io/docs/options/
- |
- | There are more options than you see here, these are just the ones that are
- | set internally. See the website for more info.
- |
  |
  */
 
@@ -25,5 +19,6 @@ module.exports = {
   watchEvents: ["change"],
   open: false,
   browser: "default",
-  ghostMode: false
+  ghostMode: false,
+  ui: false
 };


### PR DESCRIPTION
The Browsersync UI is nice, but it also takes a lot of space to output
when first starting Lucky. There is already a lot there (too much), so
by default the UI is removed. If people want it they can add it later.

This also makes it easier/faster to jump to docs and removes unnecessary
language from the comments