### PR TITLE
Remove Webpack progress

### DIFF
--- a/src/browser_app_skeleton/package.json
+++ b/src/browser_app_skeleton/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "heroku-postbuild": "yarn prod",
     "dev": "yarn run webpack --progress --hide-modules --color --config=node_modules/laravel-mix/setup/webpack.config.js",
-    "watch": "yarn run webpack --watch --progress --hide-modules --color --config=node_modules/laravel-mix/setup/webpack.config.js",
+    "watch": "yarn run webpack --watch --hide-modules --color --config=node_modules/laravel-mix/setup/webpack.config.js",
     "prod": "NODE_ENV=production yarn run webpack --progress --hide-modules --color --config=node_modules/laravel-mix/setup/webpack.config.js"
   },
   "devDependencies": {


### PR DESCRIPTION
It was super distracting and often messed up output and displayed a bunch of lines. This makes it much clearer