### PR TITLE
Rename App to AppServer and rename files accordingly

### DIFF
--- a/spec/integration/init_web_spec.cr
+++ b/spec/integration/init_web_spec.cr
@@ -41,7 +41,7 @@ describe "Initializing a new web project" do
         File.read("src/actions/users/show.cr").should_not be_nil
         File.read("src/pages/users/index_page.cr").should_not be_nil
         File.read("src/components/users/header.cr").should contain "Users::Header < BaseComponent"
-        should_run_successfully "crystal build src/server.cr"
+        should_run_successfully "crystal build src/start_server.cr"
       end
     end
   end
@@ -134,7 +134,7 @@ private def compile_and_run_specs_on_test_project
   FileUtils.cd "test-project" do
     should_run_successfully "script/setup"
     should_run_successfully "crystal tool format --check spec src"
-    should_run_successfully "crystal build src/server.cr"
+    should_run_successfully "crystal build src/start_server.cr"
     should_run_successfully "crystal build src/test_project.cr"
     should_run_successfully "crystal src/app.cr"
     should_run_successfully "crystal spec"

--- a/src/browser_app_skeleton/spec/setup/start_app_server.cr
+++ b/src/browser_app_skeleton/spec/setup/start_app_server.cr
@@ -1,10 +1,10 @@
-app = App.new
+app_server = AppServer.new
 
 spawn do
-  app.listen
+  app_server.listen
 end
 
 at_exit do
   LuckyFlow.shutdown
-  app.close
+  app_server.close
 end

--- a/src/web_app_skeleton/src/app.cr.ecr
+++ b/src/web_app_skeleton/src/app.cr.ecr
@@ -28,40 +28,4 @@ require "./pages/**"
 require "../config/env"
 require "../config/**"
 require "../db/migrations/**"
-
-class App < Lucky::BaseApp
-  def middleware
-    [
-      Lucky::ForceSSLHandler.new,
-      Lucky::HttpMethodOverrideHandler.new,
-      Lucky::LogHandler.new,
-      <%- if browser? -%>
-      Lucky::SessionHandler.new,
-      Lucky::FlashHandler.new,
-      <%- else %>
-      # Disabled in API mode, but can be enabled if you need them:
-      # Lucky::SessionHandler.new,
-      # Lucky::FlashHandler.new,
-      <%- end -%>
-      Lucky::ErrorHandler.new(action: Errors::Show),
-      Lucky::RouteHandler.new,
-      <%- if browser? -%>
-      Lucky::StaticFileHandler.new("./public", false),
-      <%- else %>
-      # Disabled in API mode:
-      # Lucky::StaticFileHandler.new("./public", false),
-      <%- end -%>
-      Lucky::RouteNotFoundHandler.new,
-    ]
-  end
-
-  def protocol
-    "http"
-  end
-
-  def listen
-    # Learn about bind_tcp: https://tinyurl.com/bind-tcp-docs
-    server.bind_tcp(host, port, reuse_port: false)
-    server.listen
-  end
-end
+require "./app_server"

--- a/src/web_app_skeleton/src/app_server.cr.ecr
+++ b/src/web_app_skeleton/src/app_server.cr.ecr
@@ -1,0 +1,36 @@
+class AppServer < Lucky::BaseAppServer
+  def middleware
+    [
+      Lucky::ForceSSLHandler.new,
+      Lucky::HttpMethodOverrideHandler.new,
+      Lucky::LogHandler.new,
+      <%- if browser? -%>
+      Lucky::SessionHandler.new,
+      Lucky::FlashHandler.new,
+      <%- else %>
+      # Disabled in API mode, but can be enabled if you need them:
+      # Lucky::SessionHandler.new,
+      # Lucky::FlashHandler.new,
+      <%- end -%>
+      Lucky::ErrorHandler.new(action: Errors::Show),
+      Lucky::RouteHandler.new,
+      <%- if browser? -%>
+      Lucky::StaticFileHandler.new("./public", false),
+      <%- else %>
+      # Disabled in API mode:
+      # Lucky::StaticFileHandler.new("./public", false),
+      <%- end -%>
+      Lucky::RouteNotFoundHandler.new,
+    ]
+  end
+
+  def protocol
+    "http"
+  end
+
+  def listen
+    # Learn about bind_tcp: https://tinyurl.com/bind-tcp-docs
+    server.bind_tcp(host, port, reuse_port: false)
+    server.listen
+  end
+end

--- a/src/web_app_skeleton/src/start_server.cr.ecr
+++ b/src/web_app_skeleton/src/start_server.cr.ecr
@@ -5,13 +5,13 @@ if Lucky::Env.development?
 end
 Habitat.raise_if_missing_settings!
 
-app = App.new
+app_server = AppServer.new
 <%- if !proxied_through_browsersync? -%>
-puts "Listening on #{app.base_uri}"
+puts "Listening on http://#{app_server.host}:#{app_server.port}"
 <%- end -%>
 
 Signal::INT.trap do
-  app.close
+  app_server.close
 end
 
-app.listen
+app_server.listen

--- a/src/web_app_skeleton/src/{{crystal_project_name}}.cr
+++ b/src/web_app_skeleton/src/{{crystal_project_name}}.cr
@@ -1,1 +1,1 @@
-require "./server"
+require "./start_server"


### PR DESCRIPTION
I think this change makes a lot more sense. The App was really a server.
So that is now renamed and moved to a separate file. `src/server.cr` was
not a server, it was starting the server. So that was also renamed.