### PR TITLE
Speed up Browsersync and make it less noisy

### DIFF
--- a/src/web_app_skeleton/bs-config.js
+++ b/src/web_app_skeleton/bs-config.js
@@ -20,5 +20,7 @@ module.exports = {
   open: false,
   browser: "default",
   ghostMode: false,
-  ui: false
+  ui: false,
+  online: false,
+  logConnections: false
 };


### PR DESCRIPTION
Browsersync is too obtrusive right now.

This makes it so there is less output (logConnections: false) and boots faster (online: false)

This does mean you can't use Browsersync externally, but I figure if you want that then you can enable it later.