### PR TITLE
move the dotenv loading before shards are loaded

### DIFF
--- a/src/web_app_skeleton/src/app.cr.ecr
+++ b/src/web_app_skeleton/src/app.cr.ecr
@@ -1,8 +1,5 @@
 require "./shards"
 
-# Load .env file before any other config or app code
-Dotenv.load
-
 <%- if browser? -%>
 # Load the asset manifest in public/mix-manifest.json
 Lucky::AssetHelpers.load_manifest

--- a/src/web_app_skeleton/src/shards.cr
+++ b/src/web_app_skeleton/src/shards.cr
@@ -1,5 +1,8 @@
-# Require your shards here
+# Load .env file before any other config or app code
 require "dotenv"
+Dotenv.load
+
+# Require your shards here
 require "avram"
 require "lucky"
 require "carbon"


### PR DESCRIPTION
This moves the Dotenv loading to be right after the require. In some cases, there may be shards that require the .env file to be loaded before they are required. Previously, that would cause those to fail since the .env was being loaded after all shards.