### PR TITLE
Move color config to config/colors.cr

### DIFF
--- a/src/web_app_skeleton/config/colors.cr
+++ b/src/web_app_skeleton/config/colors.cr
@@ -1,0 +1,4 @@
+# This enables the color output when in development or test
+# Check out the Colorize docs for more information
+# https://crystal-lang.org/api/Colorize.html
+Colorize.enabled = Lucky::Env.development? || Lucky::Env.test?

--- a/src/web_app_skeleton/config/logger.cr
+++ b/src/web_app_skeleton/config/logger.cr
@@ -1,10 +1,5 @@
 require "file_utils"
 
-# This enables the color output when in development
-# Check out the Colorize docs for more information
-# https://crystal-lang.org/api/Colorize.html
-Colorize.enabled = Lucky::Env.development?
-
 logger =
   if Lucky::Env.test?
     # Logs to `tmp/test.log` so you can see what's happening without having


### PR DESCRIPTION
I was wondering why my tests had no color and realized it should be enabled in test as well.

Also moved to its own config since it took me awhile to find it and it applies to all of Crystal, not just logging