### PR TITLE
Allow for setting a custom help message on tasks. 

### DIFF
--- a/spec/lucky_cli/runner_spec.cr
+++ b/spec/lucky_cli/runner_spec.cr
@@ -21,6 +21,30 @@ describe LuckyCli::Runner do
       .should have_called_my_cool_task
   end
 
+  it "prints the help_message for a found task when a help flag is passed" do
+    LuckyCli::Runner
+      .run(args: ["my.cool_task", "--help"])
+      .should have_default_help_message
+    LuckyCli::Runner
+      .run(args: ["my.cool_task", "-h"])
+      .should have_default_help_message
+    LuckyCli::Runner
+      .run(args: ["my.cool_task", "help"])
+      .should have_default_help_message
+  end
+
+  it "prints a custom help_message when set" do
+    LuckyCli::Runner
+      .run(args: ["my.custom_name", "-h"])
+      .should eq "Run with 'lucky my.custom_name'"
+  end
+
+  it "still calls a found task with other options passed" do
+    LuckyCli::Runner
+      .run(args: ["my.cool_task", "Taco", "--with-guac"])
+      .should have_called_my_cool_task
+  end
+
   it "does not call the task if no args passed" do
     LuckyCli::Runner
       .run(args: [] of String)
@@ -42,4 +66,8 @@ end
 
 private def have_called_my_cool_task
   eq :my_cool_task_was_called
+end
+
+private def have_default_help_message
+  eq "Run this task with `lucky my.cool_task`"
 end

--- a/spec/lucky_cli/runner_spec.cr
+++ b/spec/lucky_cli/runner_spec.cr
@@ -22,24 +22,20 @@ describe LuckyCli::Runner do
   end
 
   it "prints the help_message for a found task when a help flag is passed" do
-    LuckyCli::Runner
-      .run(args: ["my.cool_task", "--help"])
-      .should have_default_help_message
-    LuckyCli::Runner
-      .run(args: ["my.cool_task", "-h"])
-      .should have_default_help_message
-    LuckyCli::Runner
-      .run(args: ["my.cool_task", "help"])
-      .should have_default_help_message
+    %w(--help -h help).each do |help_arg|
+      io = IO::Memory.new
+      LuckyCli::Runner.run(args: ["my.cool_task", help_arg], io: io)
+      io.to_s.chomp.should have_default_help_message
+    end
   end
 
   it "prints a custom help_message when set" do
-    LuckyCli::Runner
-      .run(args: ["my.custom_name", "-h"])
-      .should eq "Run with 'lucky my.custom_name'"
+    io = IO::Memory.new
+    LuckyCli::Runner.run(args: ["my.custom_name", "-h"], io: io)
+    io.to_s.chomp.should eq "Custom help message"
   end
 
-  it "still calls a found task with other options passed" do
+  it "still calls a found task with non-help options" do
     LuckyCli::Runner
       .run(args: ["my.cool_task", "Taco", "--with-guac"])
       .should have_called_my_cool_task
@@ -69,5 +65,5 @@ private def have_called_my_cool_task
 end
 
 private def have_default_help_message
-  eq "Run this task with `lucky my.cool_task`"
+  eq "Run this task with 'lucky my.cool_task'"
 end

--- a/spec/lucky_cli/task_spec.cr
+++ b/spec/lucky_cli/task_spec.cr
@@ -15,4 +15,8 @@ describe LuckyCli::Task do
   it "creates summary text" do
     My::CoolTask.new.summary.should eq "This task does something awesome"
   end
+
+  it "has a default help message" do
+    My::CoolTask.new.help_message.should eq "Run this task with `lucky my.cool_task`"
+  end
 end

--- a/spec/lucky_cli/task_spec.cr
+++ b/spec/lucky_cli/task_spec.cr
@@ -17,6 +17,6 @@ describe LuckyCli::Task do
   end
 
   it "has a default help message" do
-    My::CoolTask.new.help_message.should eq "Run this task with `lucky my.cool_task`"
+    My::CoolTask.new.help_message.should eq "Run this task with 'lucky my.cool_task'"
   end
 end

--- a/spec/support/tasks.cr
+++ b/spec/support/tasks.cr
@@ -10,6 +10,10 @@ class Some::Other::Task < LuckyCli::Task
   summary "bar"
   name "my.custom_name"
 
+  def help_message
+    "Run with 'lucky my.custom_name'"
+  end
+
   def call
   end
 end

--- a/spec/support/tasks.cr
+++ b/spec/support/tasks.cr
@@ -11,7 +11,7 @@ class Some::Other::Task < LuckyCli::Task
   name "my.custom_name"
 
   def help_message
-    "Run with 'lucky my.custom_name'"
+    "Custom help message"
   end
 
   def call

--- a/src/lucky_cli/runner.cr
+++ b/src/lucky_cli/runner.cr
@@ -24,7 +24,7 @@ class LuckyCli::Runner
       HELP_TEXT
     else
       if task = find_task(task_name)
-        task.call
+        task.print_help_or_call(args)
       else
         TaskNotFoundErrorMessage.print(task_name)
         if exit_with_error_if_not_found?

--- a/src/lucky_cli/runner.cr
+++ b/src/lucky_cli/runner.cr
@@ -11,20 +11,20 @@ class LuckyCli::Runner
     @@tasks.sort_by!(&.name)
   end
 
-  def self.run(args = ARGV)
+  def self.run(args = ARGV, io : IO = STDERR)
     task_name = args.shift?
 
     if !task_name.nil? && ["--help", "-h"].includes?(task_name)
       puts help_text
     elsif task_name.nil?
-      STDERR.puts <<-HELP_TEXT
+      io.puts <<-HELP_TEXT
       Missing a task name
 
       To see a list of available tasks, run #{"lucky --help".colorize(:green)}
       HELP_TEXT
     else
       if task = find_task(task_name)
-        task.print_help_or_call(args)
+        task.print_help_or_call(args, io: io)
       else
         TaskNotFoundErrorMessage.print(task_name)
         if exit_with_error_if_not_found?

--- a/src/lucky_cli/task.cr
+++ b/src/lucky_cli/task.cr
@@ -7,6 +7,19 @@ abstract class LuckyCli::Task
     def name
       "{{@type.name.gsub(/::/, ".").underscore}}"
     end
+
+    def help_message
+      "Run this task with `lucky #{name}`"
+    end
+
+    def print_help_or_call(args : Array(String))
+      if args.any? { |arg| ["--help", "-h", "help"].includes?(arg) }
+        STDERR.puts help_message
+        help_message
+      else
+        call
+      end
+    end
   end
 
   macro banner(banner_text)

--- a/src/lucky_cli/task.cr
+++ b/src/lucky_cli/task.cr
@@ -9,16 +9,19 @@ abstract class LuckyCli::Task
     end
 
     def help_message
-      "Run this task with `lucky #{name}`"
+      "Run this task with 'lucky #{name}'"
     end
 
-    def print_help_or_call(args : Array(String))
-      if args.any? { |arg| ["--help", "-h", "help"].includes?(arg) }
-        STDERR.puts help_message
-        help_message
+    def print_help_or_call(args : Array(String), io : IO = STDERR)
+      if wants_help_message?(args)
+        io.puts help_message
       else
         call
       end
+    end
+
+    private def wants_help_message?(args)
+      args.any? { |arg| ["--help", "-h", "help"].includes?(arg) }
     end
   end
 


### PR DESCRIPTION
fixes #340

This PR adds in the ability to set a custom `help_message` method on tasks so people can pass one of `-h`, `--help`, or just `help` to a task to see a more detailed help message on how to run that specific task