### PR TITLE
Add /tmp to gitignore

### DIFF
--- a/src/generators/web.cr
+++ b/src/generators/web.cr
@@ -73,6 +73,7 @@ class LuckyCli::Generators::Web
     *.dwarf
     *.local.cr
     .env
+    /tmp
     TEXT
     if browser?
       append_text to: ".gitignore", text: <<-TEXT


### PR DESCRIPTION
Running tests for the first time creates a `tmp` directory. It should probably be listed in gitignore.