### PR TITLE
script/setup uses /bin/bash which is not available everywhere

### DIFF
--- a/script/setup
+++ b/script/setup
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
 # Exit if any subcommand fails
 set -e

--- a/script/test
+++ b/script/test
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
 # Exit if any subcommand fails
 set -e

--- a/src/web_app_skeleton/script/setup.ecr
+++ b/src/web_app_skeleton/script/setup.ecr
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Exit if any subcommand fails
 set -e


### PR DESCRIPTION
Some distributions do not have ```/bin/bash``` so use ```/usr/bin/env``` to find it.