### PR TITLE
Delete duplicate base_flow.cr

### DIFF
--- a/src/browser_app_skeleton/spec/flows/base_flow.cr
+++ b/src/browser_app_skeleton/spec/flows/base_flow.cr
@@ -1,3 +1,0 @@
-# Add methods that all or most Flows need to share
-class BaseFlow < LuckyFlow
-end


### PR DESCRIPTION
I believe that the intended `base_flow.cr` is found [here](https://github.com/luckyframework/lucky_cli/blob/master/src/browser_app_skeleton/spec/support/flows/base_flow.cr) and this one can be removed