### PR TITLE
adding to setup script checking for postgres

### DIFF
--- a/src/web_app_skeleton/script/setup.ecr
+++ b/src/web_app_skeleton/script/setup.ecr
@@ -14,10 +14,10 @@ indent() {
 check_postgres() {
   if ! command -v createdb > /dev/null; then
     printf 'Please install the postgres CLI tools, then try again.\n'
-    printf 'See https://www.postgresql.org/docs/current/tutorial-install.html for install instructions.\n'
     if [[ "$OSTYPE" == "darwin"* ]]; then
-      printf "\nIf you're using Postgres.app, see https://postgresapp.com/documentation/cli-tools.html.\n"
+      printf "If you're using Postgres.app, see https://postgresapp.com/documentation/cli-tools.html.\n"
     fi
+    printf 'See https://www.postgresql.org/docs/current/tutorial-install.html for install instructions.\n'
     exit 1
   fi
 
@@ -59,6 +59,7 @@ fi
 
 printf "\n▸ Checking that postgres is installed and running\n"
 check_postgres | indent
+printf "✔ Done\n" | indent
 
 printf "\n▸ Setting up the database\n"
 lucky db.create | indent

--- a/src/web_app_skeleton/script/setup.ecr
+++ b/src/web_app_skeleton/script/setup.ecr
@@ -56,6 +56,9 @@ printf "\n▸ Checking that postgres is installed\n"
 check_postgres | indent
 printf "✔ Done\n" | indent
 
+printf "\n▸ Verifying postgres connection\n"
+lucky db.verify_connection | indent
+
 printf "\n▸ Setting up the database\n"
 lucky db.create | indent
 

--- a/src/web_app_skeleton/script/setup.ecr
+++ b/src/web_app_skeleton/script/setup.ecr
@@ -11,10 +11,13 @@ indent() {
 }
 
 # Ensure postgres is installed, and booted
-ensure_postgres() {
+check_postgres() {
   if ! command -v createdb > /dev/null; then
-    printf 'Please install postgres before continuing.\n'
+    printf 'Please install the postgres CLI tools, then try again.\n'
     printf 'See https://www.postgresql.org/docs/current/tutorial-install.html for install instructions.\n'
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+      printf "\nIf you're using Postgres.app, see https://postgresapp.com/documentation/cli-tools.html.\n"
+    fi
     exit 1
   fi
 
@@ -55,7 +58,7 @@ if [ ! -f ".env" ]; then
 fi
 
 printf "\n▸ Checking that postgres is installed and running\n"
-ensure_postgres | indent
+check_postgres | indent
 
 printf "\n▸ Setting up the database\n"
 lucky db.create | indent

--- a/src/web_app_skeleton/script/setup.ecr
+++ b/src/web_app_skeleton/script/setup.ecr
@@ -10,6 +10,20 @@ indent() {
   done
 }
 
+# Ensure postgres is installed, and booted
+ensure_postgres() {
+  if ! command -v createdb > /dev/null; then
+    printf 'Please install postgres before continuing.\n'
+    printf 'See https://www.postgresql.org/docs/current/tutorial-install.html for install instructions.\n'
+    exit 1
+  fi
+
+  if ! pgrep -x "postgres" > /dev/null; then
+    printf 'Please ensure postgres is running first, then try again.\n'
+    exit 1
+  fi
+}
+
 <%- if browser? -%>
 if ! command -v yarn > /dev/null; then
   printf 'Yarn is not installed.\n'
@@ -39,6 +53,9 @@ if [ ! -f ".env" ]; then
   touch .env
   printf "✔ Done\n" | indent
 fi
+
+printf "\n▸ Checking that postgres is installed and running\n"
+ensure_postgres | indent
 
 printf "\n▸ Setting up the database\n"
 lucky db.create | indent

--- a/src/web_app_skeleton/script/setup.ecr
+++ b/src/web_app_skeleton/script/setup.ecr
@@ -10,7 +10,7 @@ indent() {
   done
 }
 
-# Ensure postgres is installed, and booted
+# Ensure postgres client tools are installed
 check_postgres() {
   if ! command -v createdb > /dev/null; then
     printf 'Please install the postgres CLI tools, then try again.\n'
@@ -18,11 +18,6 @@ check_postgres() {
       printf "If you're using Postgres.app, see https://postgresapp.com/documentation/cli-tools.html.\n"
     fi
     printf 'See https://www.postgresql.org/docs/current/tutorial-install.html for install instructions.\n'
-    exit 1
-  fi
-
-  if ! pgrep -x "postgres" > /dev/null; then
-    printf 'Please ensure postgres is running first, then try again.\n'
     exit 1
   fi
 }
@@ -57,7 +52,7 @@ if [ ! -f ".env" ]; then
   printf "✔ Done\n" | indent
 fi
 
-printf "\n▸ Checking that postgres is installed and running\n"
+printf "\n▸ Checking that postgres is installed\n"
 check_postgres | indent
 printf "✔ Done\n" | indent
 


### PR DESCRIPTION
Closes: https://github.com/luckyframework/lucky/issues/845

This PR adds a check that postgres is both installed, and running prior to running a db.create task. When postgres is installed, but not booted, you'll get a strange error that isn't quite clear what the issue is. By detecting this for the developer, we can save them some time of searching around.

On a side note, I have no clue how to test that postgres isn't running, but I did add this to a new generated lucky app, and killed my local running postgres 

<img width="800" alt="Screen Shot 2019-07-23 at 4 34 10 PM" src="https://user-images.githubusercontent.com/2391/61754373-c59abd00-ad67-11e9-80b0-31f89d4e7bb3.png">
