### PR TITLE
Annotate return types of abstract methods

### DIFF
--- a/src/base_authentication_app_skeleton/src/models/user.cr
+++ b/src/base_authentication_app_skeleton/src/models/user.cr
@@ -7,7 +7,7 @@ class User < BaseModel
     column encrypted_password : String
   end
 
-  def emailable
+  def emailable : Carbon::Address
     Carbon::Address.new(email)
   end
 end

--- a/src/web_app_skeleton/src/actions/errors/show.cr.ecr
+++ b/src/web_app_skeleton/src/actions/errors/show.cr.ecr
@@ -27,7 +27,7 @@ class Errors::Show < Lucky::ErrorAction
   end
 
   # This is the catch all method that renders unhandled exceptions
-  def handle_error(error : Exception)
+  def handle_error(error : Exception) : Lucky::Response
     Lucky.logger.error(unhandled_error: error.inspect_with_backtrace)
 
     if Lucky::ErrorHandler.settings.show_debug_output

--- a/src/web_app_skeleton/src/app_server.cr.ecr
+++ b/src/web_app_skeleton/src/app_server.cr.ecr
@@ -1,5 +1,5 @@
 class AppServer < Lucky::BaseAppServer
-  def middleware
+  def middleware : Array(HTTP::Handler)
     [
       Lucky::ForceSSLHandler.new,
       Lucky::HttpMethodOverrideHandler.new,
@@ -21,7 +21,7 @@ class AppServer < Lucky::BaseAppServer
       # Lucky::StaticFileHandler.new("./public", false),
       <%- end -%>
       Lucky::RouteNotFoundHandler.new,
-    ]
+    ] of HTTP::Handler
   end
 
   def protocol


### PR DESCRIPTION
Upon merge and release of

* https://github.com/mosop/teeplate/pull/16
* https://github.com/luckyframework/carbon/pull/24

The dependencies overrided in https://github.com/bcardiff/lucky_cli/commit/bdb7dd1752d2deafe962e2426b05c42b5533f83e should be updated before lucky_cli release