### PR TITLE
Verify connection after db create

### DIFF
--- a/src/web_app_skeleton/script/setup.ecr
+++ b/src/web_app_skeleton/script/setup.ecr
@@ -56,11 +56,11 @@ printf "\n▸ Checking that postgres is installed\n"
 check_postgres | indent
 printf "✔ Done\n" | indent
 
+printf "\n▸ Creating the database\n"
+lucky db.create | indent
+
 printf "\n▸ Verifying postgres connection\n"
 lucky db.verify_connection | indent
-
-printf "\n▸ Setting up the database\n"
-lucky db.create | indent
 
 printf "\n▸ Migrating the database\n"
 lucky db.migrate | indent


### PR DESCRIPTION
The problem was that we'd verify the connection before the db was
created.

This meant that it would always raise until the db.create ran.