### PR TITLE
Bind to localhost not 0.0.0.0

### DIFF
--- a/src/web_app_skeleton/config/watch.yml
+++ b/src/web_app_skeleton/config/watch.yml
@@ -1,2 +1,2 @@
-host: 0.0.0.0
+host: localhost
 port: 5000


### PR DESCRIPTION
A bit more secure and also prevents annoying firewall error on macOS if you have strict firewall settings

Production still uses 0.0.0.0 for stuff like Heroku that won't work with localhost