### PR TITLE
ignore node_modules with webpack watch. 

### DIFF
--- a/src/browser_app_skeleton/webpack.mix.js
+++ b/src/browser_app_skeleton/webpack.mix.js
@@ -40,7 +40,10 @@ mix
   // Reduce noise in Webpack output
   .webpackConfig({
     stats: "errors-only",
-    plugins: [webpackNotifier]
+    plugins: [webpackNotifier],
+    watchOptions: {
+      ignored: /node_modules/
+    }
   })
   // Disable default Mix notifications because we're using our own notifier
   .disableNotifications()


### PR DESCRIPTION
Fixes #367

I'm not sure how browsersync works. I thought about adding an ignore to that too, but I don't know if we need that or not. My guess is no.