### PR TITLE
Move specs to Task

### DIFF
--- a/spec/lucky_cli/runner_spec.cr
+++ b/spec/lucky_cli/runner_spec.cr
@@ -1,5 +1,7 @@
 require "../spec_helper"
 
+include HaveDefaultHelperMessageMatcher
+
 describe LuckyCli::Runner do
   it "adds tasks to the runner when task classes are created" do
     LuckyCli::Runner.tasks.map(&.name).reject(&.==("lucky_cli.dev")).should eq [
@@ -27,18 +29,6 @@ describe LuckyCli::Runner do
       LuckyCli::Runner.run(args: ["my.cool_task", help_arg], io: io)
       io.to_s.chomp.should have_default_help_message
     end
-  end
-
-  it "prints a custom help_message when set" do
-    io = IO::Memory.new
-    LuckyCli::Runner.run(args: ["my.custom_name", "-h"], io: io)
-    io.to_s.chomp.should eq "Custom help message"
-  end
-
-  it "still calls a found task with non-help options" do
-    LuckyCli::Runner
-      .run(args: ["my.cool_task", "Taco", "--with-guac"])
-      .should have_called_my_cool_task
   end
 
   it "does not call the task if no args passed" do

--- a/spec/lucky_cli/task_spec.cr
+++ b/spec/lucky_cli/task_spec.cr
@@ -1,5 +1,7 @@
 require "../spec_helper"
 
+include HaveDefaultHelperMessageMatcher
+
 private abstract class ShouldNotBlowUpForAbstractClasses < LuckyCli::Task
 end
 
@@ -18,5 +20,21 @@ describe LuckyCli::Task do
 
   it "has a default help message" do
     My::CoolTask.new.help_message.should eq "Run this task with 'lucky my.cool_task'"
+  end
+
+  describe "print_help_or_call" do
+    it "prints the help_message for a found task when a help flag is passed" do
+      %w(--help -h help).each do |help_arg|
+        io = IO::Memory.new
+        My::CoolTask.new.print_help_or_call(args: [help_arg], io: io)
+        io.to_s.chomp.should have_default_help_message
+      end
+    end
+
+    it "prints a custom help_message when set" do
+      io = IO::Memory.new
+      Some::Other::Task.new.print_help_or_call(args: ["-h"], io: io)
+      io.to_s.chomp.should eq "Custom help message"
+    end
   end
 end

--- a/spec/support/have_default_help_message_matcher.cr
+++ b/spec/support/have_default_help_message_matcher.cr
@@ -1,0 +1,5 @@
+module HaveDefaultHelperMessageMatcher
+  private def have_default_help_message
+    eq "Run this task with 'lucky my.cool_task'"
+  end
+end


### PR DESCRIPTION
Closes #417

To fix precompiled tasks, make sure to use `print_help_or_call`. This just moves specs around to make sure tasks work correctly with `print_help_or_call` to prevent any future breakage