### PR TITLE
Update JS deps

### DIFF
--- a/src/browser_app_skeleton/package.json
+++ b/src/browser_app_skeleton/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@rails/ujs": "^6.0.0",
     "normalize-scss": "^7.0.1",
-    "turbolinks": "^5.0.3"
+    "turbolinks": "^5.2.0"
   },
   "scripts": {
     "heroku-postbuild": "yarn prod",

--- a/src/browser_app_skeleton/package.json
+++ b/src/browser_app_skeleton/package.json
@@ -2,8 +2,8 @@
   "license": "UNLICENSED",
   "private": true,
   "dependencies": {
+    "@rails/ujs": "^6.0.0",
     "normalize-scss": "^7.0.1",
-    "rails-ujs": "^5.1.4",
     "turbolinks": "^5.0.3"
   },
   "scripts": {

--- a/src/browser_app_skeleton/src/js/app.js
+++ b/src/browser_app_skeleton/src/js/app.js
@@ -5,9 +5,7 @@
 require("@rails/ujs").start();
 
 // Turbolinks is optional. Learn more: https://github.com/turbolinks/turbolinks/
-import Turbolinks from "turbolinks";
-
-Turbolinks.start();
+require("turbolinks").start();
 
 // If using Turbolinks, you can attach events to page load like this:
 //

--- a/src/browser_app_skeleton/src/js/app.js
+++ b/src/browser_app_skeleton/src/js/app.js
@@ -1,13 +1,12 @@
 /* eslint no-console:0 */
 
-// RailsUjs is *required* for links in Lucky that use DELETE, POST and PUT.
+// Rails Unobtrusive JavaScript (UJS) is *required* for links in Lucky that use DELETE, POST and PUT.
 // Though it says "Rails" it actually works with any framework.
-import RailsUjs from "rails-ujs";
+require("@rails/ujs").start();
 
 // Turbolinks is optional. Learn more: https://github.com/turbolinks/turbolinks/
 import Turbolinks from "turbolinks";
 
-RailsUjs.start();
 Turbolinks.start();
 
 // If using Turbolinks, you can attach events to page load like this:


### PR DESCRIPTION
Fixes #394

In addition I've also updated Turbolinks. Rails UJS and Turbolinks are both from Rails and I think it makes sense to update both to latest versions.

I also wonder if other JS dependencies should be updated too?

Actually maybe I miss something, but is there a reason why laravel-mix's dependencies are specified explicitly and some are locked to specific version? Just a guess, but looks like everything below `"laravel-mix": "^4.0.0",` shouldn't be required.

```js
  "devDependencies": {
    "browser-sync": "^2.18.13",
    "laravel-mix": "^4.0.0",
    "resolve-url-loader": "2.3.1",
    "sass": "1.17.1",
    "sass-loader": "7.*",
    "vue-template-compiler": "^2.5.22"
  }
```