### PR TITLE
Stop logging favicon requests in development

### DIFF
--- a/src/web_app_skeleton/config/logger.cr
+++ b/src/web_app_skeleton/config/logger.cr
@@ -38,7 +38,7 @@ Lucky::LogHandler.configure do |settings|
   if Lucky::Env.development?
     settings.skip_if = ->(context : HTTP::Server::Context) {
       context.request.method.downcase == "get" &&
-      context.request.resource.starts_with?(/\/css\/|\/js\/|\/assets\//)
+      context.request.resource.starts_with?(/\/css\/|\/js\/|\/assets\/|\/favicon\.ico/)
     }
   end
 end


### PR DESCRIPTION
I've noticed `GET /favicon.ico` requests sometimes shown in development mode.

Since requests to all other assets are configured to be skipped, I think it makes sense to skip `/favicon.ico` as well.

I'm not sure however if other extensions for favicon should be specified too. As stated in https://en.wikipedia.org/wiki/Favicon other image formats like `.png`, `.gif` and so on can be used. Even path can be different.

Since the default template does not include any meta tags for favicon I think having only the default `favicon.ico` in regex might be sufficient.

**WDYT?**

As a side note **I've found out about this behavior when I was literally pulling my hair out** trying to figure out why `Lucky.logger.info` was printing info multiple times 😕 (sometimes 3, sometimes 5 🤔) when used from HTTP handler. 

Since all requests to assets are not logged and `favicon.ico` requests are rare, it took me awhile to realize that browser sometimes sends requests to just HTML and sometimes for several assets too and every sent requests result in ` more log entry.

If logging for assets would be on in development I would have noticed this quicker for sure. However since I was only seeing a single `GET /sign_in` and then all messages under it it wasn't obvious.

<details>
  <summary>See example logs</summary>

12:59:07 PM web.1   |  GET /sign_in
12:59:07 PM web.1   |   ▸ Ran FooHandler#call 1
12:59:07 PM web.1   |   ▸ Handled by SignIns::New
12:59:07 PM web.1   |   ▸ Ran verify_accepted_format
12:59:07 PM web.1   |   ▸ Ran protect_from_forgery
12:59:07 PM web.1   |   ▸ Ran test_backdoor
12:59:07 PM web.1   |   ▸ Ran redirect_signed_in_users
12:59:07 PM web.1   |   ▸ Rendered SignIns::NewPage
12:59:07 PM web.1   |   ▸ Sent 200 (1.47ms)
12:59:07 PM web.1   |   ▸ Ran FooHandler#call 2
12:59:07 PM web.1   |   ▸ Ran FooHandler#call 3
12:59:07 PM web.1   |   ▸ Ran FooHandler#call 4
</details>

**So I guess my question is - could/should something be done for my use case (logging from HTTP handlers) to avoid confusion for someone else?**

As a second side note I found this cool tool which allows inspect requests between browser and server and much more. You probably already knew, but I thought I would mention it anyways [HTTP Toolkit](https://httptoolkit.tech/)