### PR TITLE
Moving the error handler above session in the stack. 

### DIFF
--- a/src/web_app_skeleton/src/app_server.cr.ecr
+++ b/src/web_app_skeleton/src/app_server.cr.ecr
@@ -1,10 +1,10 @@
 class AppServer < Lucky::BaseAppServer
   def middleware : Array(HTTP::Handler)
     [
+      Lucky::ErrorHandler.new(action: Errors::Show),
       Lucky::ForceSSLHandler.new,
       Lucky::HttpMethodOverrideHandler.new,
       Lucky::LogHandler.new,
-      Lucky::ErrorHandler.new(action: Errors::Show),
       <%- if browser? -%>
       Lucky::SessionHandler.new,
       Lucky::FlashHandler.new,

--- a/src/web_app_skeleton/src/app_server.cr.ecr
+++ b/src/web_app_skeleton/src/app_server.cr.ecr
@@ -4,6 +4,7 @@ class AppServer < Lucky::BaseAppServer
       Lucky::ForceSSLHandler.new,
       Lucky::HttpMethodOverrideHandler.new,
       Lucky::LogHandler.new,
+      Lucky::ErrorHandler.new(action: Errors::Show),
       <%- if browser? -%>
       Lucky::SessionHandler.new,
       Lucky::FlashHandler.new,
@@ -12,7 +13,6 @@ class AppServer < Lucky::BaseAppServer
       # Lucky::SessionHandler.new,
       # Lucky::FlashHandler.new,
       <%- end -%>
-      Lucky::ErrorHandler.new(action: Errors::Show),
       Lucky::RouteHandler.new,
       <%- if browser? -%>
       Lucky::StaticFileHandler.new("./public", false),


### PR DESCRIPTION
This lets the cookie overflow error to render the exception page. Maybe it can move all the way up? Not sure if that matters or not, but moving to this position does fix the issue from https://github.com/luckyframework/lucky/issues/949