### PR TITLE
Add config folder to format check and fix files incorrectly formatted

### DIFF
--- a/spec/integration/init_web_spec.cr
+++ b/spec/integration/init_web_spec.cr
@@ -102,8 +102,8 @@ end
 
 private def compile_and_run_specs_on_test_project
   FileUtils.cd "test-project" do
+    should_run_successfully "crystal tool format --check spec src config"
     should_run_successfully "script/setup"
-    should_run_successfully "crystal tool format --check spec src"
     should_run_successfully "crystal build src/start_server.cr"
     should_run_successfully "crystal build src/test_project.cr"
     should_run_successfully "crystal src/app.cr"

--- a/src/web_app_skeleton/config/cookies.cr.ecr
+++ b/src/web_app_skeleton/config/cookies.cr.ecr
@@ -8,9 +8,8 @@ Lucky::CookieJar.configure do |settings|
   settings.on_set = ->(cookie : HTTP::Cookie) {
     # If ForceSSLHandler is enabled, only send cookies over HTTPS
     cookie.secure(Lucky::ForceSSLHandler.settings.enabled)
-
-    # You can set other defaults for cookies here. For example:
-    #
-    #    cookie.expires(1.year.from_now).domain("mydomain.com")
+  # You can set other defaults for cookies here. For example:
+  #
+  #    cookie.expires(1.year.from_now).domain("mydomain.com")
   }
 end

--- a/src/web_app_skeleton/config/cookies.cr.ecr
+++ b/src/web_app_skeleton/config/cookies.cr.ecr
@@ -8,8 +8,8 @@ Lucky::CookieJar.configure do |settings|
   settings.on_set = ->(cookie : HTTP::Cookie) {
     # If ForceSSLHandler is enabled, only send cookies over HTTPS
     cookie.secure(Lucky::ForceSSLHandler.settings.enabled)
-  # You can set other defaults for cookies here. For example:
-  #
-  #    cookie.expires(1.year.from_now).domain("mydomain.com")
+    # You can set other defaults for cookies here. For example:
+    #
+    #    cookie.expires(1.year.from_now).domain("mydomain.com")
   }
 end

--- a/src/web_app_skeleton/config/database.cr.ecr
+++ b/src/web_app_skeleton/config/database.cr.ecr
@@ -21,7 +21,7 @@ Avram.configure do |settings|
   # In production, allow lazy loading (N+1).
   # In development and test, raise an error if you forget to preload associations
   settings.lazy_load_enabled = Lucky::Env.production?
-  
+
   # Uncomment the next line to log all SQL queries
   # settings.query_log_level = ::Logger::Severity::DEBUG
 end


### PR DESCRIPTION
Just a minor nitpick but I saw that there was already a check for formatting so it seems to be the intention to have the generated code be correctly formatted.

I am not happy with the formatting on `cookies.cr.ecr`.  I will see if I can replicate it in a smaller codebase and open an issue on crystal for it.

I moved the check up since it doesn't require running `script/setup` and it will fail fast which is a whole lot better than waiting several minutes to find out the formatting is incorrect.