### PR TITLE
Use exit_code over exit_status

### DIFF
--- a/src/lucky.cr
+++ b/src/lucky.cr
@@ -43,7 +43,7 @@ elsif task_precompiled?
     input: STDIN,
     output: STDOUT,
     error: STDERR
-  ).exit_status
+  ).exit_code
 elsif File.file?(tasks_file)
   exit Process.run(
     "crystal run #{tasks_file} -- #{args}",
@@ -51,7 +51,7 @@ elsif File.file?(tasks_file)
     input: STDIN,
     output: STDOUT,
     error: STDERR
-  ).exit_status
+  ).exit_code
 else
   puts <<-MISSING_TASKS_FILE
 


### PR DESCRIPTION
Due to getting the wrong exit value when an exception happens in a file that a process calls, exit_status will be deprecated in future versions of crystal. 

```crystal
# test.cr
raise "test"

# run.cr
exit Process.run(
  "crystal run test.cr",
  shell: true,
  input: STDIN,
  output: STDOUT,
  error: STDERR).exit_status

# $ crystal test.cr; echo $? #=> 1
# $ crystal run.cr; echo $? #=> 0
```

Fixes #434