### PR TITLE
Adding ability to set custom directory when using custom.init

### DIFF
--- a/spec/integration/deploy_to_heroku_spec.cr
+++ b/spec/integration/deploy_to_heroku_spec.cr
@@ -38,6 +38,7 @@ require "../spec_helper"
   private def generate_heroku_app_name
     app_name_base + "-" + Random::Secure.hex(4)
   end
+
   private def app_name_base
     ENV["HEROKU_APP_NAME"]? || "lucky-integration"
   end

--- a/spec/integration/init_web_spec.cr
+++ b/spec/integration/init_web_spec.cr
@@ -62,7 +62,7 @@ describe "Initializing a new web project" do
   end
 
   it "creates a full app in a different directory" do
-    puts "Web app with custom directory: Running integration spec. This might take awhile...".colorize(:yellow)
+    puts "Web app with custom directory: Running integration spec.".colorize(:yellow)
     FileUtils.mkdir_p "/tmp/home/bob"
     should_run_successfully "crystal run src/lucky.cr -- init.custom test-project --dir /tmp/home/bob"
     FileUtils.cd "/tmp/home/bob/test-project" do
@@ -74,7 +74,7 @@ describe "Initializing a new web project" do
     FileUtils.mkdir "test-project"
     output = IO::Memory.new
     Process.run(
-      "crystal run src/lucky.cr -- init.custom test-project test-project",
+      "crystal run src/lucky.cr -- init.custom test-project",
       output: output,
       shell: true
     )
@@ -97,7 +97,7 @@ describe "Initializing a new web project" do
   it "translates dashes to underscores in the project name" do
     output = IO::Memory.new
     Process.run(
-      "crystal run src/lucky.cr -- init.custom test-project 'test-project'",
+      "crystal run src/lucky.cr -- init.custom test-project",
       env: ENV.to_h,
       output: output,
       shell: true

--- a/spec/integration/init_web_spec.cr
+++ b/spec/integration/init_web_spec.cr
@@ -9,7 +9,7 @@ end
 describe "Initializing a new web project" do
   it "creates a full web app successfully" do
     puts "Web app: Running integration spec. This might take awhile...".colorize(:yellow)
-    should_run_successfully "crystal run src/lucky.cr -- init.custom test-project test-project"
+    should_run_successfully "crystal run src/lucky.cr -- init.custom test-project"
     FileUtils.cp("spec/support/cat.gif", "test-project/public/assets/images/")
 
     File.delete("test-project/.env")
@@ -22,7 +22,7 @@ describe "Initializing a new web project" do
 
   it "creates a full web app with generator" do
     puts "Web app generators: Running integration spec. This might take awhile...".colorize(:yellow)
-    should_run_successfully "crystal run src/lucky.cr -- init.custom test-project test-project"
+    should_run_successfully "crystal run src/lucky.cr -- init.custom test-project"
 
     FileUtils.cd "test-project" do
       should_run_successfully "shards install"
@@ -45,20 +45,29 @@ describe "Initializing a new web project" do
 
   it "creates an api only web app successfully" do
     puts "Api only: Running integration spec. This might take awhile...".colorize(:yellow)
-    should_run_successfully "crystal run src/lucky.cr -- init.custom test-project test-project --api"
+    should_run_successfully "crystal run src/lucky.cr -- init.custom test-project --api"
     compile_and_run_specs_on_test_project
   end
 
   it "creates an api only app without auth" do
     puts "Api only without auth: Running integration spec. This might take awhile...".colorize(:yellow)
-    should_run_successfully "crystal run src/lucky.cr -- init.custom test-project test-project --api --no-auth"
+    should_run_successfully "crystal run src/lucky.cr -- init.custom test-project --api --no-auth"
     compile_and_run_specs_on_test_project
   end
 
   it "creates a full app without auth" do
     puts "Web app without auth: Running integration spec. This might take awhile...".colorize(:yellow)
-    should_run_successfully "crystal run src/lucky.cr -- init.custom test-project test-project --no-auth"
+    should_run_successfully "crystal run src/lucky.cr -- init.custom test-project --no-auth"
     compile_and_run_specs_on_test_project
+  end
+
+  it "creates a full app in a different directory" do
+    puts "Web app with custom directory: Running integration spec. This might take awhile...".colorize(:yellow)
+    FileUtils.mkdir_p "/tmp/home/bob"
+    should_run_successfully "crystal run src/lucky.cr -- init.custom test-project --dir /tmp/home/bob"
+    FileUtils.cd "/tmp/home/bob/test-project" do
+      File.read("src/shards.cr").should contain "lucky"
+    end
   end
 
   it "does not create project if directory with same name already exist" do

--- a/src/custom_init.cr
+++ b/src/custom_init.cr
@@ -13,14 +13,18 @@ class LuckyCli::CustomInit < LuckyCli::Init
   private def generate_project(project_name)
     api_only = false
     authentication = true
+    project_directory = "."
     OptionParser.parse do |parser|
       parser.banner = <<-TEXT
       Usage: lucky custom.init NAME [arguments]
 
-      Example: lucky custom.init my_api --api --no-auth
+      Example: lucky custom.init my_api --api --no-auth --dir ~/Projects/
       TEXT
       parser.on("--api", "Generates an api-only web app") { api_only = true }
       parser.on("--no-auth", "Does not generate authentication") { authentication = false }
+      parser.on("--dir DIRECTORY", "Specify the directory to generate your app in. Default is current directory") { |dir|
+        project_directory = dir
+      }
       parser.on("-h", "--help", "This help message") {
         puts parser
         exit(0)
@@ -30,7 +34,8 @@ class LuckyCli::CustomInit < LuckyCli::Init
     LuckyCli::Generators::Web.run(
       project_name: project_name.to_s,
       api_only: api_only,
-      generate_auth: authentication
+      generate_auth: authentication,
+      project_directory: project_directory
     )
   end
 end

--- a/src/custom_init.cr
+++ b/src/custom_init.cr
@@ -18,10 +18,13 @@ class LuckyCli::CustomInit < LuckyCli::Init
       parser.banner = <<-TEXT
       Usage: lucky custom.init NAME [arguments]
 
-      Example: lucky custom.init my_api --api --no-auth --dir ~/Projects/
+      Examples:
+
+        lucky custom.init my_project
+        lucky custom.init my_api --api --no-auth --dir ~/Projects/
       TEXT
       parser.on("--api", "Generates an api-only web app") { api_only = true }
-      parser.on("--no-auth", "Does not generate authentication") { authentication = false }
+      parser.on("--no-auth", "Skips generating authentication") { authentication = false }
       parser.on("--dir DIRECTORY", "Specify the directory to generate your app in. Default is current directory") { |dir|
         project_directory = dir
       }

--- a/src/generators/web.cr
+++ b/src/generators/web.cr
@@ -9,8 +9,11 @@ class LuckyCli::Generators::Web
   def initialize(
     project_name : String,
     @api_only : Bool,
-    @generate_auth : Bool
+    @generate_auth : Bool,
+    project_directory : String = "."
   )
+    Dir.cd(File.expand_path(project_directory))
+
     @project_dir = project_name
     @project_name = @project_dir.gsub('-', '_')
 


### PR DESCRIPTION
Fixes #339

Right now we have a `custom.init` generator that I don't think is used much. It only does the same as the wizard, but all through the command line. Now we can start to allow for some really custom options like setting a custom directory!

This PR adds a new `--dir DIR` flag to set the directory of where to generate your application. All it really does is cd in to that custom directory, and then generate the app as normal from that directory. This may be helpful for people using docker, or automating a build on to a server.

```
lucky custom.init my-project --dir /home/me/projects
```

