### PR TITLE
adding in a generated default DB port.

### DIFF
--- a/src/web_app_skeleton/config/database.cr.ecr
+++ b/src/web_app_skeleton/config/database.cr.ecr
@@ -7,6 +7,7 @@ AppDatabase.configure do |settings|
     settings.url = ENV["DATABASE_URL"]? || Avram::PostgresURL.build(
       database: database_name,
       hostname: ENV["DB_HOST"]? || "localhost",
+      port: ENV["DB_PORT"]? || "5432",
       # Some common usernames are "postgres", "root", or your system username (run 'whoami')
       username: ENV["DB_USERNAME"]? || "postgres",
       # Some Postgres installations require no password. Use "" if that is the case.


### PR DESCRIPTION
In the PR https://github.com/luckyframework/avram/pull/333 we are removing the default port value to fix some other issues with connecting to sockets. This PR adds in the port default to your new generated lucky app.