### PR TITLE
Raise helpful permit columns error in Shared::Field

### DIFF
--- a/src/browser_app_skeleton/src/components/shared/field.cr
+++ b/src/browser_app_skeleton/src/components/shared/field.cr
@@ -29,6 +29,9 @@
 # different in different parts of your app, e.g. `CompactField` or
 # `InlineTextField`
 class Shared::Field(T) < BaseComponent
+  # Raises a helpful error if component receives an unpermitted attribute
+  include Lucky::CatchUnpermittedAttribute
+
   needs attribute : Avram::PermittedAttribute(T)
   needs label_text : String?
 


### PR DESCRIPTION
This error always happened when calling the input/label methods, but
if you used the Shared::Field component you'd get a generic "no overload
matches".

This module added in https://github.com/luckyframework/lucky/pull/1052
makes it so you get the same nice error in field components.

This greatly improves the ease of use and DX when using Lucky.