### PR TITLE
Default cookies to http only

### DIFF
--- a/src/web_app_skeleton/config/cookies.cr.ecr
+++ b/src/web_app_skeleton/config/cookies.cr.ecr
@@ -8,6 +8,10 @@ Lucky::CookieJar.configure do |settings|
   settings.on_set = ->(cookie : HTTP::Cookie) {
     # If ForceSSLHandler is enabled, only send cookies over HTTPS
     cookie.secure(Lucky::ForceSSLHandler.settings.enabled)
+
+    # By default, don't allow reading cookies with JavaScript
+    cookie.http_only(true)
+
     # You can set other defaults for cookies here. For example:
     #
     #    cookie.expires(1.year.from_now).domain("mydomain.com")


### PR DESCRIPTION
Closes #455

By default cookies are signed and encrypted (and therefore useless) to
JavaScript. So we may as well set them to HTTP only for additional
security.