### PR TITLE
Disable directory listing

### DIFF
--- a/src/web_app_skeleton/src/app_server.cr.ecr
+++ b/src/web_app_skeleton/src/app_server.cr.ecr
@@ -19,11 +19,11 @@ class AppServer < Lucky::BaseAppServer
       Lucky::RouteHandler.new,
       <%- if browser? -%>
       Lucky::StaticCompressionHandler.new("./public", file_ext: "gz", content_encoding: "gzip"),
-      Lucky::StaticFileHandler.new("./public", false),
+      Lucky::StaticFileHandler.new("./public", fallthrough: false, directory_listing: false),
       <%- else %>
       # Disabled in API mode:
       # Lucky::StaticCompressionHandler.new("./public", file_ext: "gz", content_encoding: "gzip"),
-      # Lucky::StaticFileHandler.new("./public", false),
+      # Lucky::StaticFileHandler.new("./public", fallthrough: false, directory_listing: false),
       <%- end -%>
       Lucky::RouteNotFoundHandler.new,
     ] of HTTP::Handler


### PR DESCRIPTION
Fixes https://github.com/luckyframework/lucky/issues/1117

The StaticFileHandler has directory_listing enabled by default, but it's a weird option that feels like it's more commonly turned off. This also makes it clear how you can flip it back on if you really like it.