### PR TITLE
Pin jwt on 1.4.1 untill Crystal 0.35 is supported

### DIFF
--- a/src/generators/web.cr
+++ b/src/generators/web.cr
@@ -177,7 +177,7 @@ class LuckyCli::Generators::Web
       append_text to: "shard.yml", text: <<-DEPS_LIST
         jwt:
           github: crystal-community/jwt
-          version: ~> 1.4.0
+          version: 1.4.1
       DEPS_LIST
     end
   end


### PR DESCRIPTION
Version [1.4.2 of crystal-community/jwt](https://github.com/crystal-community/jwt/releases/tag/v1.4.2) made a breaking change of requiring a new method only available from Crystal v0.35.0, which gives an error when running `lucky dev`.

[Source of change mentioned](https://github.com/crystal-community/jwt/commit/29a3b1cb910ae12f9728f0598124ebe841eb71b8)