### PR TITLE
Adds in new lucky db.setup task to replace calling create and migrate

### DIFF
--- a/src/web_app_skeleton/script/setup.ecr
+++ b/src/web_app_skeleton/script/setup.ecr
@@ -30,14 +30,8 @@ if [ ! -f ".env" ]; then
   print_done
 fi
 
-notice "Creating the database"
-lucky db.create | indent
-
-notice "Verifying postgres connection"
-lucky db.verify_connection | indent
-
-notice "Migrating the database"
-lucky db.migrate | indent
+notice "Creating and Migrating the database"
+lucky db.setup | indent
 
 notice "Seeding the database with required and sample records"
 lucky db.create_required_seeds | indent


### PR DESCRIPTION
Fixes #513

Instead of calling create and migrate separately, we can now just call `db.setup` which does both in a single process. This will speed up setup just slightly. Also removed the `db.verify_connection` because you can't call it before the db exists otherwise connection fails. And if the `db.setup` works, then the `verify_connection` has already been met. That makes this irrelevant. 

For a future idea, maybe we can pass an arg to verify_connection that just ensures you have a connection to the PG engine itself. For example, you can connect to AWS RDS with these credentials, so you have the ability to call create or migrate if you want.. 