### PR TITLE
Render a 404 error when you get a RecordNotFoundError. 

### DIFF
--- a/src/web_app_skeleton/src/actions/errors/show.cr.ecr
+++ b/src/web_app_skeleton/src/actions/errors/show.cr.ecr
@@ -8,9 +8,9 @@ class Errors::Show < Lucky::ErrorAction
   <%- else -%>
   default_format :html
   <%- end -%>
-  dont_report [Lucky::RouteNotFoundError]
+  dont_report [Lucky::RouteNotFoundError, Avram::RecordNotFoundError]
 
-  def render(error : Lucky::RouteNotFoundError)
+  def render(error : Lucky::RouteNotFoundError | Avram::RecordNotFoundError)
     <%- if api_only? -%>
     error_json "Not found", status: 404
     <%- else -%>


### PR DESCRIPTION
Fixes #150

Generated apps will now send all record not found errors to 404, and ignore reporting them to bug trackers.

I'm actually surprised we haven't added this in yet, and no one has mentioned it... We've been using this in our apps for a long time now because we get people hitting pages like `/whatever/SELECT*FROM%20users` and all that. 