### PR TITLE
Add Ameba checks to CI and fix non-compliant code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: "*"
 
 jobs:
-  lint:
+  check_format:
     runs-on: ubuntu-latest
     container:
       image: crystallang/crystal:0.35.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Format
         run: crystal tool format --check
       - name: Crystal Ameba Linter
-        uses: crystal-ameba/github-action@v0.2.5
+        uses: crystal-ameba/github-action@v0.2.6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,12 @@ name: Lucky CLI CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
     branches: "*"
 
 jobs:
-  check_format:
+  lint:
     runs-on: ubuntu-latest
     container:
       image: crystallang/crystal:0.35.0
@@ -17,6 +17,11 @@ jobs:
         run: shards install
       - name: Format
         run: crystal tool format --check
+      - name: Crystal Ameba Linter
+        uses: crystal-ameba/github-action@v0.2.5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   specs:
     runs-on: ubuntu-latest
     container:
@@ -41,7 +46,7 @@ jobs:
         run: apt-get -yqq install chromium-chromedriver
       - uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: "12.x"
       - name: Install yarn
         run: npm install -g yarn
       - name: Run setup script

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,7 @@ jobs:
       - name: Format
         run: crystal tool format --check
       - name: Crystal Ameba Linter
-        uses: crystal-ameba/github-action@v0.2.6
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./bin/ameba
 
   specs:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ The name is inferred from the name of the class unless explicitly set with `name
 You can see all available tasks by running `lucky --help`
 
 ## Documentation
+
 [API (master)](https://luckyframework.github.io/lucky_cli/)
 
 ## Contributing
@@ -77,7 +78,7 @@ You can see all available tasks by running `lucky --help`
 1.  Create your feature branch (git checkout -b my-new-feature)
 1.  Commit your changes (git commit -am 'Add some feature')
 1.  Push to the branch (git push origin my-new-feature)
-1.  Check that specs on Travis CI pass
+1.  Check that specs on GitHub Actions CI pass
 1.  Create a new Pull Request
 
 ## Testing Deployment to Heroku

--- a/script/test
+++ b/script/test
@@ -4,5 +4,24 @@
 set -e
 set -o pipefail
 
-printf "\nrunning specs with 'crystal spec'\n\n"
+printf "\nChecking code formatting...\n\n"
+
+if ! crystal tool format --check src spec > /dev/null; then
+    printf "\nCode is not formatted.\n"
+    printf "\nFormat the code with: crystal tool format src spec\n\n"
+    exit 1
+else
+    printf "\nCrystal format checks passed.\n\n"
+fi
+
+if ! crystal ./bin/ameba.cr; then
+    printf "\nCode did not pass Ameba checks.\n"
+    printf "\nResolve Ameba linter errors, then run this checker again\n\n"
+    exit 1
+else
+    printf "\nAmeba linter checks passed.\n\n"
+fi
+
+printf "\nRunning specs with 'crystal spec'\n\n"
 crystal spec "$@"
+

--- a/shard.yml
+++ b/shard.yml
@@ -12,3 +12,8 @@ dependencies:
   teeplate:
     github: luckyframework/teeplate
     version: ~> 0.8.2
+
+development_dependencies:
+  ameba:
+    github: crystal-ameba/ameba
+    version: ~> 0.13

--- a/spec/integration/init_web_spec.cr
+++ b/spec/integration/init_web_spec.cr
@@ -103,7 +103,7 @@ describe "Initializing a new web project" do
       shell: true
     )
 
-    shard_yml_name = File.read_lines("test-project/shard.yml").select { |line| line =~ /^name:/ }.first
+    shard_yml_name = File.read_lines("test-project/shard.yml").find { |line| line =~ /^name:/ }
     shard_yml_name.should eq("name: test_project")
     File.exists?("test-project/src/test_project.cr").should be_true
   end

--- a/src/api_authentication_app_skeleton/src/models/user_token.cr
+++ b/src/api_authentication_app_skeleton/src/models/user_token.cr
@@ -13,8 +13,10 @@ class UserToken
     JWT.encode(payload, Lucky::Server.settings.secret_key_base, ALGORITHM)
   end
 
+  # Both the payload and header are provided from the JWT decode method
+  # Should you require the header, modify the `_` variable below to something like `header`
   def self.decode_user_id(token : String) : Int64?
-    payload, _header = JWT.decode(token, Lucky::Server.settings.secret_key_base, ALGORITHM)
+    payload, _ = JWT.decode(token, Lucky::Server.settings.secret_key_base, ALGORITHM)
     payload["user_id"].to_s.to_i64
   rescue e : JWT::Error
     Lucky::Log.dexter.error { {jwt_decode_error: e.message} }

--- a/src/api_authentication_app_skeleton/src/models/user_token.cr
+++ b/src/api_authentication_app_skeleton/src/models/user_token.cr
@@ -13,10 +13,8 @@ class UserToken
     JWT.encode(payload, Lucky::Server.settings.secret_key_base, ALGORITHM)
   end
 
-  # Both the payload and header are provided from the JWT decode method
-  # Should you require the header, modify the `_` variable below to something like `header`
   def self.decode_user_id(token : String) : Int64?
-    payload, _ = JWT.decode(token, Lucky::Server.settings.secret_key_base, ALGORITHM)
+    payload, _header = JWT.decode(token, Lucky::Server.settings.secret_key_base, ALGORITHM)
     payload["user_id"].to_s.to_i64
   rescue e : JWT::Error
     Lucky::Log.dexter.error { {jwt_decode_error: e.message} }

--- a/src/lucky_cli/spinner.cr
+++ b/src/lucky_cli/spinner.cr
@@ -35,7 +35,7 @@ class LuckyCli::Spinner
 
   def self.start(*args, **named_args)
     spinner = new(*args, **named_args).start
-    yield.tap do |last_value_from_block|
+    yield.tap do |_last_value_from_block|
       spinner.stop
     end
   end


### PR DESCRIPTION
This pull request seeks to do a few things:

- Adds a checker to the `script/test` script to ensure that `crystal tool format` passes
- Adds a checker to the CLI code itself in both `script/test` and the CLI pipeline to ensure that the Ameba linter passes
- Brings the CLI code itself into a state where it passes the Ameba linter
- Brings the generated application code into a state where any `lucky init` app should pass the Ameba linter

I was having trouble running these tests locally (`crystal spec` was failing a single integration, but running the integration on its own passed), so I'd like to see the GitHub action results on this PR before changing anything else.

As always, open to feedback on a change in direction for any of this.