### PR TITLE
Added a catch for reserved project names

### DIFF
--- a/spec/integration/init_web_spec.cr
+++ b/spec/integration/init_web_spec.cr
@@ -94,6 +94,18 @@ describe "Initializing a new web project" do
     output.to_s.strip.should contain(message)
   end
 
+  it "does not create project if the project name is reserved" do
+    output = IO::Memory.new
+    Process.run(
+      "crystal run src/lucky.cr -- init.custom 'app'",
+      env: ENV.to_h,
+      output: output,
+      shell: true
+    )
+    message = "Projects cannot be named app, app_database, app_server, shards, start_server."
+    output.to_s.strip.should contain(message)
+  end
+
   it "translates dashes to underscores in the project name" do
     output = IO::Memory.new
     Process.run(

--- a/src/lucky_cli/project_name.cr
+++ b/src/lucky_cli/project_name.cr
@@ -20,20 +20,18 @@ class LuckyCli::ProjectName
       <<-TEXT
       Project name can't be blank
       TEXT
+    elsif RESERVED_PROJECT_NAMES.includes?(sanitized_name)
+      <<-TEXT
+      Projects cannot be named #{RESERVED_PROJECT_NAMES.join(", ")}.
+
+      How about: 'my_lucky_app'?
+      TEXT
     else
-      if RESERVED_PROJECT_NAMES.includes?(sanitized_name)
-        <<-TEXT
-        Projects cannot be named #{RESERVED_PROJECT_NAMES.join(", ")}.
+      <<-TEXT
+      Project name should only contain lowercase letters, numbers, underscores, and dashes.
 
-        How about: 'my_lucky_app'?
-        TEXT
-      else
-        <<-TEXT
-        Project name should only contain lowercase letters, numbers, underscores, and dashes.
-
-        How about: '#{sanitized_name}'?
-        TEXT
-      end
+      How about: '#{sanitized_name}'?
+      TEXT
     end
   end
 

--- a/src/lucky_cli/project_name.cr
+++ b/src/lucky_cli/project_name.cr
@@ -1,4 +1,6 @@
 class LuckyCli::ProjectName
+  RESERVED_PROJECT_NAMES = {"app", "app_database", "app_server", "shards", "start_server"}
+
   getter name
   delegate empty?, to: name
 
@@ -10,7 +12,7 @@ class LuckyCli::ProjectName
   end
 
   def valid? : Bool
-    (sanitized_name == name) && !empty?
+    (sanitized_name == name) && !empty? && (!RESERVED_PROJECT_NAMES.includes?(sanitized_name))
   end
 
   def validation_error_message : String
@@ -19,11 +21,19 @@ class LuckyCli::ProjectName
       Project name can't be blank
       TEXT
     else
-      <<-TEXT
-      Project name should only contain lowercase letters, numbers, underscores, and dashes.
+      if RESERVED_PROJECT_NAMES.includes?(sanitized_name)
+        <<-TEXT
+        Projects cannot be named #{RESERVED_PROJECT_NAMES.join(", ")}.
 
-      How about: '#{sanitized_name}'?
-      TEXT
+        How about: 'my_lucky_app'?
+        TEXT
+      else
+        <<-TEXT
+        Project name should only contain lowercase letters, numbers, underscores, and dashes.
+
+        How about: '#{sanitized_name}'?
+        TEXT
+      end
     end
   end
 


### PR DESCRIPTION
Fixes #540

There's a small chance that when someone is trying Lucky for the first time, they may just generate an app called "app" just to get through the wizard. Doing this would overwrite the `src/app.cr` file which causes some funky stuff. In this PR I just added all of the pre-existing file names to avoid any of that. 