### PR TITLE
Revert DATABASE_URL rename to DB_URL

### DIFF
--- a/src/web_app_skeleton/config/database.cr.ecr
+++ b/src/web_app_skeleton/config/database.cr.ecr
@@ -2,9 +2,9 @@ database_name = "<%= crystal_project_name %>_#{Lucky::Env.name}"
 
 AppDatabase.configure do |settings|
   if Lucky::Env.production?
-    settings.credentials = Avram::Credentials.parse(ENV["DB_URL"])
+    settings.credentials = Avram::Credentials.parse(ENV["DATABASE_URL"])
   else
-    settings.credentials = Avram::Credentials.parse?(ENV["DB_URL"]?) || Avram::Credentials.new(
+    settings.credentials = Avram::Credentials.parse?(ENV["DATABASE_URL"]?) || Avram::Credentials.new(
       database: database_name,
       hostname: ENV["DB_HOST"]? || "localhost",
       port: ENV["DB_PORT"]?.try(&.to_i) || 5432,


### PR DESCRIPTION
This PR aims to make default-generated apps work with most DB services again
by renaming DB_URL back to DATABASE_URL.