### PR TITLE
Rename with_defaults to tag_defaults

### DIFF
--- a/shard.override.yml
+++ b/shard.override.yml
@@ -3,9 +3,9 @@
 
 # NOTE: https://github.com/crystal-lang/shards/issues/432
 # Until this is resolved, the default needs to be empty here.
-dependencies: {}
+# dependencies: {}
 # Uncomment if you need to override
-# dependencies:
-#   lucky:
-#     github: luckyframework/lucky
-#     branch: master
+dependencies:
+  lucky:
+    github: luckyframework/lucky
+    branch: master

--- a/src/browser_app_skeleton/src/components/shared/field.cr
+++ b/src/browser_app_skeleton/src/components/shared/field.cr
@@ -40,11 +40,11 @@ class Shared::Field(T) < BaseComponent
 
     # You can add more default options here. For example:
     #
-    #    with_defaults field: attribute, class: "input"
+    #    tag_defaults field: attribute, class: "input"
     #
     # Will add the class "input" to the generated HTML.
-    with_defaults field: attribute do |input_builder|
-      yield input_builder
+    tag_defaults field: attribute do |tag_builder|
+      yield tag_builder
     end
 
     mount Shared::FieldErrors, attribute


### PR DESCRIPTION
This PR aims to close #548

It will need to be released in conjunction with https://github.com/luckyframework/lucky/pull/1262

This PR tackles:
- Renaming with_defaults in `browser_app_skeleton/src/components/shared/field.cr` to the new `tag_defaults` signature implemented [here](https://github.com/luckyframework/lucky/pull/1262)
- Renaming the yielded block from `input_builder` to `tag_builder` to keep all Lucky-generated docs/code/comments consistent and (hopefully) better convey meaning

I wasn't sure how to get the specs passing here since the method won't be found in Lucky until a new version is available.