### PR TITLE
Default to printing emails to logs in development

### DIFF
--- a/src/web_app_skeleton/config/email.cr
+++ b/src/web_app_skeleton/config/email.cr
@@ -7,6 +7,8 @@ BaseEmail.configure do |settings|
     # If you do need emails, get a key from SendGrid and set an ENV variable
     send_grid_key = send_grid_key_from_env
     settings.adapter = Carbon::SendGridAdapter.new(api_key: send_grid_key)
+  elsif Lucky::Env.development?
+    settings.adapter = Carbon::DevAdapter.new(print_emails: true)
   else
     settings.adapter = Carbon::DevAdapter.new
   end


### PR DESCRIPTION
This PR aims to make debugging emails a bit more straightforward for new Lucky users. I remember being quite confused the first time I tried to send an email in dev and ended up enabling SendGrid since I couldn't determine how to show the email content.

Since then, I've dug into the Carbon source and found the nifty `print_emails` option when initializing a `Carbon::DevAdapter`! I think it'd be handy to turn that on by default in dev, especially since if it's too noisy turning the flag off is pretty straightforward.

If this isn't agreeable, there are a few other options that could help (that I'm happy to open issues/PRs for):
- Add documentation for the `print_emails` flag to the Carbon readme
- Add documentation for the `print_emails` flag to the Lucky guides