### PR TITLE
Task cli arg update

### DIFF
--- a/spec/lucky_cli/task_spec.cr
+++ b/spec/lucky_cli/task_spec.cr
@@ -73,6 +73,12 @@ describe LuckyCli::Task do
       end
     end
 
+    it "provides an example for the error message on args" do
+      expect_raises(Exception, /Example: dark/) do
+        TaskWithRequiredFormatArgs.new.print_help_or_call(args: ["--theme=Spooky"])
+      end
+    end
+
     it "sets switch flags that default to false" do
       task = TaskWithSwitchFlags.new.print_help_or_call(args: [] of String).not_nil!
       task.admin?.should eq false
@@ -90,7 +96,13 @@ describe LuckyCli::Task do
     end
 
     it "raises an error if the positional arg doesn't match the format" do
-      expect_raises(Exception, /Invalid format for columns/) do
+      expect_raises(Exception, /Invalid format for model/) do
+        TaskWithPositionalArgs.new.print_help_or_call(args: ["user", "name"])
+      end
+    end
+
+    it "provides an example for the error message on positional_arg" do
+      expect_raises(Exception, /Example: name:String/) do
         TaskWithPositionalArgs.new.print_help_or_call(args: ["User", "name"])
       end
     end

--- a/spec/lucky_cli/task_spec.cr
+++ b/spec/lucky_cli/task_spec.cr
@@ -93,4 +93,14 @@ describe LuckyCli::Task do
       end
     end
   end
+
+  describe "output" do
+    it "allows you to specify where the output is written to" do
+      task = TaskWithFancyOutput.new
+      task.output = IO::Memory.new
+
+      task.call
+      task.output.to_s.should contain "Fancy output"
+    end
+  end
 end

--- a/spec/lucky_cli/task_spec.cr
+++ b/spec/lucky_cli/task_spec.cr
@@ -27,16 +27,18 @@ describe LuckyCli::Task do
   describe "print_help_or_call" do
     it "prints the help_message for a found task when a help flag is passed" do
       %w(--help -h help).each do |help_arg|
-        io = IO::Memory.new
-        My::CoolTask.new.print_help_or_call(args: [help_arg], io: io)
-        io.to_s.should have_default_help_message
+        task = My::CoolTask.new
+        task.output = IO::Memory.new
+        task.print_help_or_call(args: [help_arg])
+        task.output.to_s.should have_default_help_message
       end
     end
 
     it "prints a custom help_message when set" do
-      io = IO::Memory.new
-      Some::Other::Task.new.print_help_or_call(args: ["-h"], io: io)
-      io.to_s.chomp.should eq "Custom help message"
+      task = Some::Other::Task.new
+      task.output = IO::Memory.new
+      task.print_help_or_call(args: ["-h"])
+      task.output.to_s.chomp.should eq "Custom help message"
     end
   end
 

--- a/spec/support/tasks.cr
+++ b/spec/support/tasks.cr
@@ -65,3 +65,12 @@ class TaskWithPositionalArgs < LuckyCli::Task
     self
   end
 end
+
+class TaskWithFancyOutput < LuckyCli::Task
+  summary "This is a task with some fancy output"
+
+  def call
+    output.puts "Fancy output".colorize.green
+    self
+  end
+end

--- a/spec/support/tasks.cr
+++ b/spec/support/tasks.cr
@@ -37,7 +37,10 @@ end
 
 class TaskWithRequiredFormatArgs < LuckyCli::Task
   summary "This task has a required arg with a format"
-  arg :theme, description: "Specifies which theme to use. Must be dark or light", format: /^(dark|light)$/
+  arg :theme,
+      description: "Specifies which theme to use. Must be dark or light",
+      format: /^(dark|light)$/,
+      example: "dark"
 
   def call
     self
@@ -59,7 +62,11 @@ class TaskWithPositionalArgs < LuckyCli::Task
   summary "This is a task with positional args"
 
   positional_arg :model, "Define the model", format: /^[A-Z]/
-  positional_arg :columns, "Define the columns like name:String", to_end: true, format: /\w+:[A-Z]\w+(::\w+)?/
+  positional_arg :columns,
+                 "Define the columns like name:String",
+                 to_end: true,
+                 format: /\w+:[A-Z]\w+(::\w+)?/,
+                 example: "name:String"
 
   def call
     self

--- a/spec/support/tasks.cr
+++ b/spec/support/tasks.cr
@@ -38,9 +38,9 @@ end
 class TaskWithRequiredFormatArgs < LuckyCli::Task
   summary "This task has a required arg with a format"
   arg :theme,
-      description: "Specifies which theme to use. Must be dark or light",
-      format: /^(dark|light)$/,
-      example: "dark"
+    description: "Specifies which theme to use. Must be dark or light",
+    format: /^(dark|light)$/,
+    example: "dark"
 
   def call
     self
@@ -63,10 +63,10 @@ class TaskWithPositionalArgs < LuckyCli::Task
 
   positional_arg :model, "Define the model", format: /^[A-Z]/
   positional_arg :columns,
-                 "Define the columns like name:String",
-                 to_end: true,
-                 format: /\w+:[A-Z]\w+(::\w+)?/,
-                 example: "name:String"
+    "Define the columns like name:String",
+    to_end: true,
+    format: /\w+:[A-Z]\w+(::\w+)?/,
+    example: "name:String"
 
   def call
     self

--- a/src/lucky_cli/runner.cr
+++ b/src/lucky_cli/runner.cr
@@ -24,7 +24,8 @@ class LuckyCli::Runner
       HELP_TEXT
     else
       if task = find_task(task_name)
-        task.print_help_or_call(args, io: io)
+        task.output = io
+        task.print_help_or_call(args)
       else
         TaskNotFoundErrorMessage.print(task_name)
         if exit_with_error_if_not_found?

--- a/src/lucky_cli/task.cr
+++ b/src/lucky_cli/task.cr
@@ -81,7 +81,8 @@ abstract class LuckyCli::Task
   # * `description` : String - The help text description for this option
   # * `to_end` : Bool - Capture all args from this position to the end.
   # * `format` : Regex - The format you expect the args to match
-  macro positional_arg(arg_name, description, to_end = false, format = nil)
+  # * `example` : String - An example string that matches the given `format`
+  macro positional_arg(arg_name, description, to_end = false, format = nil, example = nil)
     {% PARSER_OPTS << arg_name %}
     @{{ arg_name.id }} : {% if to_end %}Array(String){% else %}String{% end %} | Nil
 
@@ -94,7 +95,12 @@ abstract class LuckyCli::Task
       {% if format %}
       matches = value.is_a?(Array) ? value.all?(&.=~({{ format }})) : value =~ {{ format }}
       if !matches
-        raise "Invalid format for {{ arg_name.id }}. It should match {{ format }}"
+        raise <<-ERROR
+        Invalid format for {{ arg_name.id }}. It should match {{ format }}
+        {% if example %}
+          Example: {{ example.id }}
+        {% end %}
+        ERROR
       end
       {% end %}
       @{{ arg_name.id }} = value
@@ -117,7 +123,8 @@ abstract class LuckyCli::Task
   # * `shorcut` : String - An optional short flag (e.g. -a VALUE)
   # * `optional` : Bool - When false, raise exception if this arg is not passed
   # * `format` : Regex - The format you expect the args to match
-  macro arg(arg_name, description, shortcut = nil, optional = false, format = nil)
+  # * `example` : String - An example string that matches the given `format`
+  macro arg(arg_name, description, shortcut = nil, optional = false, format = nil, example = nil)
     {% PARSER_OPTS << arg_name %}
     @{{ arg_name.id }} : String?
 
@@ -130,7 +137,12 @@ abstract class LuckyCli::Task
         value = value.strip
         {% if format %}
         if value !~ {{ format }}
-          raise "Invalid format for {{ arg_name.id }}. It should match {{ format }}"
+          raise <<-ERROR
+          Invalid format for {{ arg_name.id }}. It should match {{ format }}
+          {% if example %}
+            Example: {{ example.id }}
+          {% end %}
+          ERROR
         end
         {% end %}
         @{{ arg_name.id }} = value

--- a/src/lucky_cli/task.cr
+++ b/src/lucky_cli/task.cr
@@ -22,7 +22,7 @@ abstract class LuckyCli::Task
     end
 
     @[Deprecated("Set #output instead of passing in `io`")]
-    def print_help_or_call(args : Array(String), io : IO = STDERR)
+    def print_help_or_call(args : Array(String), io : IO)
       @output = io
       print_help_or_call(args)
     end

--- a/src/lucky_cli/task.cr
+++ b/src/lucky_cli/task.cr
@@ -3,6 +3,7 @@ abstract class LuckyCli::Task
     PARSER_OPTS = [] of Symbol
     @positional_arg_count : Int32 = 0
     property option_parser : OptionParser = OptionParser.new
+    property output : IO = STDOUT
 
     {% if !@type.abstract? %}
       LuckyCli::Runner.tasks << self.new

--- a/src/lucky_cli/task.cr
+++ b/src/lucky_cli/task.cr
@@ -21,9 +21,9 @@ abstract class LuckyCli::Task
       TEXT
     end
 
-    def print_help_or_call(args : Array(String), io : IO = STDERR)
+    def print_help_or_call(args : Array(String))
       if wants_help_message?(args)
-        io.puts help_message
+        output.puts help_message
       else
         \{% for opt in @type.constant(:PARSER_OPTS) %}
         set_opt_for_\{{ opt.id }}(args)

--- a/src/lucky_cli/task.cr
+++ b/src/lucky_cli/task.cr
@@ -38,11 +38,6 @@ abstract class LuckyCli::Task
     end
   end
 
-  macro banner(banner_text)
-    {% puts "DEPRECATION WARNING: LuckyCli 'banner' has been renamed to 'summary'. Please use 'summary' in #{@type.name}" %}
-    summary({{banner_text}})
-  end
-
   macro summary(summary_text)
     def summary
       {{summary_text}}

--- a/src/lucky_cli/task.cr
+++ b/src/lucky_cli/task.cr
@@ -21,6 +21,12 @@ abstract class LuckyCli::Task
       TEXT
     end
 
+    @[Deprecated("Set #output instead of passing in `io`")]
+    def print_help_or_call(args : Array(String), io : IO = STDERR)
+      @output = io
+      print_help_or_call(args)
+    end
+
     def print_help_or_call(args : Array(String))
       if wants_help_message?(args)
         output.puts help_message


### PR DESCRIPTION
Fixes  #556 (or at least makes it a little more tolerable)

This PR does a few things for Tasks:

* Removed old deprecated `banner` macro
* Adds a new `output` property which is used for testing purposes
* Adds new `example` option to `arg` and `positional_arg` to help clarify the error output when a format is used

Currently with some tasks like [gen.page](https://github.com/luckyframework/lucky/blob/master/tasks/gen/page.cr#L20) we override the `call` method to take an option `IO` which is only used to test the output. The issue is that with the new CLI args, you have to pass them to `print_help_or_call` which calls `call`. With this `output` property, we can now set that to whatever we need (`IO::Memory.new`) and test that `our_task.output.to_s` contains whatever we're looking for. 