### PR TITLE
Install browser in CI instead of Chromedriver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,8 @@ jobs:
           apt-get update
           apt-get -yqq install libpq-dev postgresql-client
       - uses: actions/checkout@v2
-      - name: Install Chromedriver
-        run: apt-get -yqq install chromium-chromedriver
+      - name: Install browser
+        run: apt-get -yqq install chromium-browser
       - uses: actions/setup-node@v1
         with:
           node-version: "12.x"

--- a/src/web_app_skeleton/.github/workflows/ci.yml.ecr
+++ b/src/web_app_skeleton/.github/workflows/ci.yml.ecr
@@ -46,8 +46,8 @@ jobs:
         apt-get update
         apt-get -yqq install libpq-dev postgresql-client
 <%- if browser? -%>
-    - name: Install Chromedriver
-      run: apt-get -yqq install chromium-chromedriver
+    - name: Install browser
+      run: apt-get -yqq install chromium-browser
 
     - uses: actions/setup-node@v1
       with:


### PR DESCRIPTION
Let webdrivers.cr install chromedriver for appropriate browser.

Closes #564 

Tested and verified here: https://github.com/stephendolan/lucky_jumpstart/runs/1298680502