### PR TITLE
Use Dependabot to automatically bump generated dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: master
+    reviewers:
+      - stephendolan
+
+  - package-ecosystem: npm
+    directory: "/src/browser-app-skeleton"
+    schedule:
+      interval: daily
+    target-branch: master
+    versioning-strategy: increase
+    reviewers:
+      - stephendolan


### PR DESCRIPTION
Closes #562 

Note that I've set myself as the reviewer for these to hopefully reduce the anxiety any other team members have about the maintenance burden.

I'll revisit in a few months to see if we should just add the entire team as the default "reviewer" field.