### PR TITLE
Add `task` env detection

### DIFF
--- a/src/web_app_skeleton/config/env.cr
+++ b/src/web_app_skeleton/config/env.cr
@@ -10,4 +10,8 @@ module Lucky::Env
   def name
     ENV["LUCKY_ENV"]? || "development"
   end
+  
+  def task?
+    ENV["LUCKY_TASK"]? == "true"
+  end
 end

--- a/src/web_app_skeleton/config/env.cr
+++ b/src/web_app_skeleton/config/env.cr
@@ -10,7 +10,7 @@ module Lucky::Env
   def name
     ENV["LUCKY_ENV"]? || "development"
   end
-  
+
   def task?
     ENV["LUCKY_TASK"]? == "true"
   end

--- a/src/web_app_skeleton/tasks.cr
+++ b/src/web_app_skeleton/tasks.cr
@@ -4,6 +4,7 @@
 #
 # Learn to create your own tasks:
 # https://luckyframework.org/guides/command-line-tasks/custom-tasks
+ENV["LUCKY_TASK"] = "true"
 
 # Load Lucky and the app (actions, models, etc.)
 require "./src/app"


### PR DESCRIPTION
I think it'd be nice to know that a task runner is calling your app code sometimes. So these changes add an env var to the entrypoint `tasks.cr` and a helper in the env config.

My specific use case is that I have some code I want to run during server startup, but not during `db.migrate` and friends. This PR will allow me to guard that code like so:

```crystal
Something.init unless Lucky::Env.task?
```