### PR TITLE
Raise log level on DB::Log to :info

### DIFF
--- a/src/web_app_skeleton/config/log.cr
+++ b/src/web_app_skeleton/config/log.cr
@@ -20,6 +20,7 @@ else
   backend = Log::IOBackend.new
   backend.formatter = Lucky::PrettyLogFormatter.proc
   Log.dexter.configure(:debug, backend)
+  DB::Log.level = :info
 end
 
 # Lucky only logs when before/after pipes halt by redirecting, or rendering a


### PR DESCRIPTION
This will prevent Crystal DB from flooding the console with "Executing
Query" messages for every query executed.

This:

![image](https://user-images.githubusercontent.com/208647/102384216-b1251900-3f89-11eb-98e3-0d0c904592cb.png)

Becomes this once again:

![image](https://user-images.githubusercontent.com/208647/102384294-cac66080-3f89-11eb-8ce6-6b4dd2fc554b.png)
