### PR TITLE
Upgrade to Laravel Mix 6

### DIFF
--- a/src/browser_app_skeleton/package.json
+++ b/src/browser_app_skeleton/package.json
@@ -8,18 +8,18 @@
   },
   "scripts": {
     "heroku-postbuild": "yarn prod",
-    "dev": "yarn run webpack --progress --hide-modules --color --config=node_modules/laravel-mix/setup/webpack.config.js",
-    "watch": "yarn run webpack --watch --hide-modules --color --config=node_modules/laravel-mix/setup/webpack.config.js",
-    "prod": "NODE_ENV=production yarn run webpack --progress --hide-modules --color --config=node_modules/laravel-mix/setup/webpack.config.js"
+    "dev": "mix",
+    "watch": "mix watch",
+    "prod": "mix --production"
   },
   "devDependencies": {
     "@babel/compat-data": "^7.9.0",
     "browser-sync": "^2.26.7",
-    "compression-webpack-plugin": "^6.0.1",
-    "laravel-mix": "^5.0.5",
+    "compression-webpack-plugin": "^7.0.0",
+    "laravel-mix": "^6.0.0",
+    "postcss": "^8.1.0",
     "resolve-url-loader": "^3.1.1",
     "sass": "^1.26.10",
-    "sass-loader": "^10.0.2",
-    "vue-template-compiler": "^2.6.12"
+    "sass-loader": "^10.0.2"
   }
 }

--- a/src/browser_app_skeleton/webpack.mix.js
+++ b/src/browser_app_skeleton/webpack.mix.js
@@ -46,7 +46,7 @@ mix
   // https://github.com/JeffreyWay/laravel-mix/blob/master/docs/mixjs.md
   .js("src/js/app.js", "public/js")
   // SASS entry file. Uses autoprefixer automatically.
-  .sass("src/css/app.scss", "public/css")
+  .sass("src/css/app.scss", "css")
   // Customize postCSS:
   // https://github.com/JeffreyWay/laravel-mix/blob/master/docs/css-preprocessors.md#postcss-plugins
   .options({
@@ -73,7 +73,6 @@ mix
 
 // Full API
 // Docs: https://github.com/JeffreyWay/laravel-mix/tree/master/docs#readme
-// Source: node_modules/laravel-mix/setup/webpack.mix.js
 //
 // mix.js(src, output);
 // mix.react(src, output); <-- Identical to mix.js(), but registers React Babel compilation.

--- a/src/browser_app_skeleton/webpack.mix.js
+++ b/src/browser_app_skeleton/webpack.mix.js
@@ -27,7 +27,7 @@ if (mix.inProduction()) {
   })
   plugins.push(gzipCompression)
 
-  // Add additional compression plugins here. 
+  // Add additional compression plugins here.
   // For example if you want to add Brotli compression:
   //
   // let brotliCompression = new CompressionWepackPlugin({
@@ -40,11 +40,13 @@ if (mix.inProduction()) {
 }
 
 mix
+  // Set public path so manifest gets output here
+  .setPublicPath("public")
   // JS entry file. Supports Vue, and uses Babel
   //
   // More info and options (like React support) here:
   // https://github.com/JeffreyWay/laravel-mix/blob/master/docs/mixjs.md
-  .js("src/js/app.js", "public/js")
+  .js("src/js/app.js", "js")
   // SASS entry file. Uses autoprefixer automatically.
   .sass("src/css/app.scss", "css")
   // Customize postCSS:
@@ -56,8 +58,6 @@ mix
     // Stops Mix from clearing the console when compilation succeeds
     clearConsole: false
   })
-  // Set public path so manifest gets output here
-  .setPublicPath("public")
   // Add assets to the manifest
   .version(["public/assets"])
   // Reduce noise in Webpack output


### PR DESCRIPTION
Laravel Mix 6 dropped today!

I've been running the beta in 3 production apps for the last few weeks, so I believe it's relatively safe to include in our next CLI release for all generated apps.

It also significantly reduces the code in our `package.json` scripts, which might be a bit mysterious behind the `mix` abstraction, but I see as a definite bonus personally.

Here are the release notes:
https://github.com/JeffreyWay/laravel-mix/blob/master/CHANGELOG.md#60