### PR TITLE
Add inline docs for new LUCKY_TASK env in scaffolded apps

### DIFF
--- a/src/web_app_skeleton/config/env.cr
+++ b/src/web_app_skeleton/config/env.cr
@@ -11,6 +11,9 @@ module Lucky::Env
     ENV["LUCKY_ENV"]? || "development"
   end
 
+  # Returns true if a task is being run through the `lucky` cli
+  #
+  # Use this method to only run (or avoid running) code when a task is executed.
   def task?
     ENV["LUCKY_TASK"]? == "true"
   end

--- a/src/web_app_skeleton/tasks.cr
+++ b/src/web_app_skeleton/tasks.cr
@@ -4,6 +4,8 @@
 #
 # Learn to create your own tasks:
 # https://luckyframework.org/guides/command-line-tasks/custom-tasks
+
+# See `Lucky::Env#task?` in `config/env.cr`
 ENV["LUCKY_TASK"] = "true"
 
 # Load Lucky and the app (actions, models, etc.)


### PR DESCRIPTION
Fixes #590

Give users context for this new method so that they know when to use it and if they need it.