### PR TITLE
Rename db.seed.required_data in github ci

### DIFF
--- a/src/web_app_skeleton/.github/workflows/ci.yml.ecr
+++ b/src/web_app_skeleton/.github/workflows/ci.yml.ecr
@@ -108,7 +108,7 @@ jobs:
       run: |
         ./lucky_tasks db.create
         ./lucky_tasks db.migrate
-        ./lucky_tasks db.create_required_seeds
+        ./lucky_tasks db.seed.required_data
 
     - name: Run tests
       run: crystal spec


### PR DESCRIPTION
I created a new project and my GitHub actions was throwing an error since `db.create_required_seeds` does not exist. It was renamed `db.seed.required_data`.