### PR TITLE
Bump generated Carbon dependency version to 0.1.3

### DIFF
--- a/src/generators/web.cr
+++ b/src/generators/web.cr
@@ -159,7 +159,7 @@ class LuckyCli::Generators::Web
         version: ~> 0.7.2
       carbon:
         github: luckyframework/carbon
-        version: ~> 0.1.2
+        version: ~> 0.1.3
       dotenv:
         github: gdotdesign/cr-dotenv
         version: ~> 0.7.0


### PR DESCRIPTION
This may have been intentional, but it appears as though we released an 0.36.1 compatible release for Carbon that we're not leveraging by default for generated apps.

Here's the Carbon commit:
https://github.com/luckyframework/carbon/commit/e36bcb35a77b64cfe297dd96e9854d8d510657ae