### PR TITLE
New generated apps will set the cookie.samesite to lax by default.

### DIFF
--- a/src/web_app_skeleton/config/cookies.cr.ecr
+++ b/src/web_app_skeleton/config/cookies.cr.ecr
@@ -12,6 +12,9 @@ Lucky::CookieJar.configure do |settings|
     # By default, don't allow reading cookies with JavaScript
     cookie.http_only(true)
 
+    # Restrict cookies to a first-party or same-site context
+    cookie.samesite(:lax)
+
     # You can set other defaults for cookies here. For example:
     #
     #    cookie.expires(1.year.from_now).domain("mydomain.com")


### PR DESCRIPTION
Fixes #514

It sounds like the original browser default for this was `NONE`, but that's not valid anymore. Now the new default it `LAX`. I'm currently using `:strict` in a new app that seems to be working fine.

This is the best explanation I found:

> If the user is on www.web.dev and requests an image from static.web.dev then that is a same-site request.

`STRICT` means "the cookie will only be sent if the site for the cookie matches the site currently shown in the browser's URL bar". 
`LAX` means "allow cookies to be sent during requests from outside of the domain (e.g. from an email)".

[more info](https://web.dev/samesite-cookies-explained/#explicitly-state-cookie-usage-with-the-samesite-attribute)