### PR TITLE
feat(database config): use DATABASE_URL in .env for all environments

### DIFF
--- a/src/web_app_skeleton/config/database.cr.ecr
+++ b/src/web_app_skeleton/config/database.cr.ecr
@@ -1,17 +1,39 @@
-database_name = "<%= crystal_project_name %>_#{Lucky::Env.name}"
+def database_url_credentials
+  Avram::Credentials.parse?(ENV["DATABASE_URL"]?)
+end
+
+def database
+  "<%= crystal_project_name %>_#{Lucky::Env.name}"
+end
+
+def hostname
+  database_url_credentials.try(&.hostname) || ENV["DB_HOST"]? || "localhost"
+end
+
+def port
+  database_url_credentials.try(&.port) || ENV["DB_PORT"]?.try(&.to_i) || 5432
+end
+
+# Some common usernames are "postgres", "root", or your system username (run 'whoami')
+def username
+  database_url_credentials.try(&.username) || ENV["DB_USERNAME"]? || "postgres"
+end
+
+# Some Postgres installations require no password. Use "" if that is the case.
+def password
+  database_url_credentials.try(&.password) || ENV["DB_PASSWORD"]? || "postgres"
+end
 
 AppDatabase.configure do |settings|
   if Lucky::Env.production?
     settings.credentials = Avram::Credentials.parse(ENV["DATABASE_URL"])
   else
-    settings.credentials = Avram::Credentials.parse?(ENV["DATABASE_URL"]?) || Avram::Credentials.new(
-      database: database_name,
-      hostname: ENV["DB_HOST"]? || "localhost",
-      port: ENV["DB_PORT"]?.try(&.to_i) || 5432,
-      # Some common usernames are "postgres", "root", or your system username (run 'whoami')
-      username: ENV["DB_USERNAME"]? || "postgres",
-      # Some Postgres installations require no password. Use "" if that is the case.
-      password: ENV["DB_PASSWORD"]? || "postgres"
+    settings.credentials = Avram::Credentials.new(
+      database: database,
+      hostname: hostname,
+      port: port,
+      username: username,
+      password: password
     )
   end
 end


### PR DESCRIPTION
This change allows me to use a single line in .env as per below:

```DATABASE_URL=postgres://lucky:developer@localhost:5432/<app_name>```

and not have tests trash my development database, whilst still working as is for production.
