### PR TITLE
lock ameba to latest 0.13 due to a bug in 0.14

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -20,4 +20,4 @@ dependencies:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 0.13
+    version: ~> 0.13.4


### PR DESCRIPTION
0.14 throws a ton of new suggestions which in some cases aren't always the best suggestions. For now we can stick with the 0.13 branch.