### PR TITLE
Drop support for 0.36.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,6 @@ jobs:
       fail-fast: false
       matrix:
         crystal_version:
-          - 0.36.1
           - 1.0.0
         experimental:
           - false
@@ -36,7 +35,6 @@ jobs:
       fail-fast: false
       matrix:
         crystal_version:
-          - 0.36.1
           - 1.0.0
         experimental:
           - false

--- a/shard.yml
+++ b/shard.yml
@@ -8,7 +8,7 @@ targets:
   lucky:
     main: src/lucky.cr
 
-crystal: ">= 0.36.1, < 2.0.0"
+crystal: ">= 1.0.0"
 
 license: MIT
 


### PR DESCRIPTION
Lucky recently dropped support for 0.36.1, only supporting 1.0.0 or
greater.

See https://github.com/luckyframework/lucky/pull/1532 for details.