### PR TITLE
Replace `normalize-scss` with `modern-normalize`

### DIFF
--- a/src/browser_app_skeleton/package.json
+++ b/src/browser_app_skeleton/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "dependencies": {
     "@rails/ujs": "^6.0.0",
-    "normalize-scss": "^7.0.1",
+    "modern-normalize": "^1.1.0",
     "turbolinks": "^5.2.0"
   },
   "scripts": {

--- a/src/browser_app_skeleton/src/css/app.scss
+++ b/src/browser_app_skeleton/src/css/app.scss
@@ -11,7 +11,7 @@
 // Note: importing with `~` tells webpack to look in the installed npm packages
 // https://stackoverflow.com/questions/39535760/what-does-a-tilde-in-a-css-url-do
 
-@import "~normalize-scss/sass/normalize/import-now";
+@import 'modern-normalize/modern-normalize.css';
 // Add your own components and import them like this:
 //
 // @import "components/my_new_component";


### PR DESCRIPTION
[normalize-scss](https://github.com/JohnAlbin/normalize-scss) hasn't had an update in three years and its pretty unlikely the following deprecation warning will be fixed any time soon.

<img width="937" alt="Screenshot 2021-07-02 at 21 48 06" src="https://user-images.githubusercontent.com/503025/124322338-8d20d200-db7f-11eb-9c23-cba4842fc31b.png">

[sindresorhus](https://github.com/sindresorhus) maintains [modern-normalize](https://github.com/sindresorhus/modern-normalize) and its regularly kept up-to-date. It's not a 1-1 replacement though, see https://github.com/sindresorhus/modern-normalize#differences-from-normalizecss for details.

Personally, I think it's a fair trade off. If you need something more sophisticated, it's easy enough to swap out.