### PR TITLE
Use Lucky::EnforceUnderscoredRoute

### DIFF
--- a/src/browser_app_skeleton/src/actions/browser_action.cr.ecr
+++ b/src/browser_app_skeleton/src/actions/browser_action.cr.ecr
@@ -1,5 +1,6 @@
 abstract class BrowserAction < Lucky::Action
   include Lucky::ProtectFromForgery
+  include Lucky::EnforceUnderscoredRoute
   accepted_formats [:html, :json], default: :html
   <%- if generate_auth? -%>
 

--- a/src/web_app_skeleton/src/actions/api_action.cr.ecr
+++ b/src/web_app_skeleton/src/actions/api_action.cr.ecr
@@ -1,6 +1,5 @@
 # Include modules and add methods that are for all API requests
 abstract class ApiAction < Lucky::Action
-  include Lucky::EnforceUnderscoredRoute
   # APIs typically do not need to send cookie/session data.
   # Remove this line if you want to send cookies in the response header.
   disable_cookies

--- a/src/web_app_skeleton/src/actions/api_action.cr.ecr
+++ b/src/web_app_skeleton/src/actions/api_action.cr.ecr
@@ -1,5 +1,6 @@
 # Include modules and add methods that are for all API requests
 abstract class ApiAction < Lucky::Action
+  include Lucky::EnforceUnderscoredRoute
   # APIs typically do not need to send cookie/session data.
   # Remove this line if you want to send cookies in the response header.
   disable_cookies
@@ -12,4 +13,5 @@ abstract class ApiAction < Lucky::Action
   # Add 'include Api::Auth::SkipRequireAuthToken' to your actions to allow all requests.
   include Api::Auth::RequireAuthToken
   <%- end -%>
+  include Lucky::EnforceUnderscoredRoute
 end


### PR DESCRIPTION
I think this uses lucky master because of the shard override. Is that right @jwoertink? Seems to be since the specs are not blowing up complaining about a module not existing 😆