### PR TITLE
Replace lucky env module

### DIFF
--- a/src/browser_app_skeleton/config/html_page.cr
+++ b/src/browser_app_skeleton/config/html_page.cr
@@ -1,3 +1,3 @@
 Lucky::HTMLPage.configure do |settings|
-  settings.render_component_comments = !Lucky::Env.production?
+  settings.render_component_comments = !LuckyEnv.production?
 end

--- a/src/browser_authentication_app_skeleton/src/actions/mixins/auth/test_backdoor.cr
+++ b/src/browser_authentication_app_skeleton/src/actions/mixins/auth/test_backdoor.cr
@@ -4,7 +4,7 @@ module Auth::TestBackdoor
   end
 
   private def test_backdoor
-    if Lucky::Env.test? && (user_id = params.get?(:backdoor_user_id))
+    if LuckyEnv.test? && (user_id = params.get?(:backdoor_user_id))
       user = UserQuery.find(user_id)
       sign_in user
     end

--- a/src/web_app_skeleton/config/authentic.cr
+++ b/src/web_app_skeleton/config/authentic.cr
@@ -3,7 +3,7 @@ require "./server"
 Authentic.configure do |settings|
   settings.secret_key = Lucky::Server.settings.secret_key_base
 
-  unless Lucky::Env.production?
+  unless LuckyEnv.production?
     fastest_encryption_possible = 4
     settings.encryption_cost = fastest_encryption_possible
   end

--- a/src/web_app_skeleton/config/colors.cr
+++ b/src/web_app_skeleton/config/colors.cr
@@ -1,4 +1,4 @@
 # This enables the color output when in development or test
 # Check out the Colorize docs for more information
 # https://crystal-lang.org/api/Colorize.html
-Colorize.enabled = Lucky::Env.development? || Lucky::Env.test?
+Colorize.enabled = LuckyEnv.development? || LuckyEnv.test?

--- a/src/web_app_skeleton/config/database.cr.ecr
+++ b/src/web_app_skeleton/config/database.cr.ecr
@@ -1,7 +1,7 @@
-database_name = "<%= crystal_project_name %>_#{Lucky::Env.name}"
+database_name = "<%= crystal_project_name %>_#{LuckyEnv.environment}"
 
 AppDatabase.configure do |settings|
-  if Lucky::Env.production?
+  if LuckyEnv.production?
     settings.credentials = Avram::Credentials.parse(ENV["DATABASE_URL"])
   else
     settings.credentials = Avram::Credentials.parse?(ENV["DATABASE_URL"]?) || Avram::Credentials.new(
@@ -21,5 +21,5 @@ Avram.configure do |settings|
 
   # In production, allow lazy loading (N+1).
   # In development and test, raise an error if you forget to preload associations
-  settings.lazy_load_enabled = Lucky::Env.production?
+  settings.lazy_load_enabled = LuckyEnv.production?
 end

--- a/src/web_app_skeleton/config/email.cr
+++ b/src/web_app_skeleton/config/email.cr
@@ -1,7 +1,7 @@
 require "carbon_sendgrid_adapter"
 
 BaseEmail.configure do |settings|
-  if Lucky::Env.production?
+  if LuckyEnv.production?
     # If you don't need to send emails, set the adapter to DevAdapter instead:
     #
     #   settings.adapter = Carbon::DevAdapter.new
@@ -9,7 +9,7 @@ BaseEmail.configure do |settings|
     # If you do need emails, get a key from SendGrid and set an ENV variable
     send_grid_key = send_grid_key_from_env
     settings.adapter = Carbon::SendGridAdapter.new(api_key: send_grid_key)
-  elsif Lucky::Env.development?
+  elsif LuckyEnv.development?
     settings.adapter = Carbon::DevAdapter.new(print_emails: true)
   else
     settings.adapter = Carbon::DevAdapter.new

--- a/src/web_app_skeleton/config/env.cr
+++ b/src/web_app_skeleton/config/env.cr
@@ -1,20 +1,33 @@
-module Lucky::Env
-  extend self
+# Environments are managed using `LuckyEnv`. By default, development, production
+# and test are supported. See
+# https://luckyframework.org/guides/getting-started/configuration for details.
+#
+# The default environment is development unless the environment variable
+# LUCKY_ENV is set.
+#
+# Example:
+# ```
+# LuckyEnv.environment  # => "development"
+# LuckyEnv.development? # => true
+# LuckyEnv.production?  # => false
+# LuckyEnv.test?        # => false
+# ```
+#
+# New environments can be added using the `LuckyEnv.add_env` macro.
+#
+# Example:
+# ```
+# LuckyEnv.add_env :staging
+# LuckyEnv.staging? # => false
+# ```
+#
+# To determine whether or not a `LuckyTask` is currently running, you can use
+# the `LuckyEnv.task?` predicate.
+#
+# Example:
+# ```
+# LuckyEnv.task? # => false
+# ```
 
-  {% for env in [:development, :test, :production] %}
-    def {{ env.id }}?
-      name == {{ env.id.stringify }}
-    end
-  {% end %}
-
-  def name
-    ENV["LUCKY_ENV"]? || "development"
-  end
-
-  # Returns true if a task is being run through the `lucky` cli
-  #
-  # Use this method to only run (or avoid running) code when a task is executed.
-  def task?
-    ENV["LUCKY_TASK"]? == "true"
-  end
-end
+# Add a staging environment.
+# LuckyEnv.add_env :staging

--- a/src/web_app_skeleton/config/error_handler.cr
+++ b/src/web_app_skeleton/config/error_handler.cr
@@ -1,3 +1,3 @@
 Lucky::ErrorHandler.configure do |settings|
-  settings.show_debug_output = !Lucky::Env.production?
+  settings.show_debug_output = !LuckyEnv.production?
 end

--- a/src/web_app_skeleton/config/log.cr
+++ b/src/web_app_skeleton/config/log.cr
@@ -1,6 +1,6 @@
 require "file_utils"
 
-if Lucky::Env.test?
+if LuckyEnv.test?
   # Logs to `tmp/test.log` so you can see what's happening without having
   # a bunch of log output in your spec results.
   FileUtils.mkdir_p("tmp")
@@ -8,7 +8,7 @@ if Lucky::Env.test?
   backend = Log::IOBackend.new(File.new("tmp/test.log", mode: "w"))
   backend.formatter = Lucky::PrettyLogFormatter.proc
   Log.dexter.configure(:debug, backend)
-elsif Lucky::Env.production?
+elsif LuckyEnv.production?
   # Lucky uses JSON in production so logs can be searched more easily
   #
   # If you want logs like in develpoment use 'Lucky::PrettyLogFormatter.proc'.
@@ -36,7 +36,7 @@ Avram::QueryLog.dexter.configure(:none)
 
 # Skip logging static assets requests in development
 Lucky::LogHandler.configure do |settings|
-  if Lucky::Env.development?
+  if LuckyEnv.development?
     settings.skip_if = ->(context : HTTP::Server::Context) {
       context.request.method.downcase == "get" &&
       context.request.resource.starts_with?(/\/css\/|\/js\/|\/assets\/|\/favicon\.ico/)

--- a/src/web_app_skeleton/config/route_helper.cr
+++ b/src/web_app_skeleton/config/route_helper.cr
@@ -1,6 +1,6 @@
 # This is used when generating URLs for your application
 Lucky::RouteHelper.configure do |settings|
-  if Lucky::Env.production?
+  if LuckyEnv.production?
     # Example: https://my_app.com
     settings.base_uri = ENV.fetch("APP_DOMAIN")
   else

--- a/src/web_app_skeleton/config/server.cr.ecr
+++ b/src/web_app_skeleton/config/server.cr.ecr
@@ -3,7 +3,7 @@
 # Look at config/route_helper.cr if you want to change the domain used when
 # generating links with `Action.url`.
 Lucky::Server.configure do |settings|
-  if Lucky::Env.production?
+  if LuckyEnv.production?
     settings.secret_key_base = secret_key_from_env
     settings.host = "0.0.0.0"
     settings.port = ENV["PORT"].to_i
@@ -26,7 +26,7 @@ Lucky::Server.configure do |settings|
   # However you could use a CDN when in production like this:
   #
   #   Lucky::Server.configure do |settings|
-  #     if Lucky::Env.production?
+  #     if LuckyEnv.production?
   #       settings.asset_host = "https://mycdnhost.com"
   #     else
   #       settings.asset_host = ""
@@ -39,7 +39,7 @@ Lucky::ForceSSLHandler.configure do |settings|
   # To force SSL in production, uncomment the lines below.
   # This will cause http requests to be redirected to https:
   #
-  #    settings.enabled = Lucky::Env.production?
+  #    settings.enabled = LuckyEnv.production?
   #    settings.strict_transport_security = {max_age: 1.year, include_subdomains: true}
   #
   # Or, leave it disabled:

--- a/src/web_app_skeleton/src/start_server.cr.ecr
+++ b/src/web_app_skeleton/src/start_server.cr.ecr
@@ -2,7 +2,7 @@ require "./app"
 
 Habitat.raise_if_missing_settings!
 
-if Lucky::Env.development?
+if LuckyEnv.development?
   Avram::Migrator::Runner.new.ensure_migrated!
   Avram::SchemaEnforcer.ensure_correct_column_mappings!
 end

--- a/src/web_app_skeleton/tasks.cr
+++ b/src/web_app_skeleton/tasks.cr
@@ -5,7 +5,7 @@
 # Learn to create your own tasks:
 # https://luckyframework.org/guides/command-line-tasks/custom-tasks
 
-# See `Lucky::Env#task?` in `config/env.cr`
+# See `LuckyEnv#task?`
 ENV["LUCKY_TASK"] = "true"
 
 # Load Lucky and the app (actions, models, etc.)


### PR DESCRIPTION
This attempts to replace the `Lucky::Env` module with `LuckyEnv`. I was not entirely sure how we want to go about structuring the `env.cr` file. So any feedback is appreciated. 🙂

Closes #654.