### PR TITLE
Fix precompiled task arguments

### DIFF
--- a/src/lucky.cr
+++ b/src/lucky.cr
@@ -40,7 +40,8 @@ elsif ["-v", "--version"].includes?(task_name)
   puts LuckyCli::VERSION
 elsif task_precompiled?
   exit Process.run(
-    "#{precompiled_task_path.not_nil!} #{ARGV.skip(1).join(" ")}",
+    precompiled_task_path.not_nil!,
+    ARGV.skip(1),
     shell: true,
     input: STDIN,
     output: STDOUT,


### PR DESCRIPTION
Te ensure quoted arguments are handled properly, we need to pass the
array of `String` arguments separately.

As an example, previously the following would not work:

```console
$ lucky exec -e "mate -w"
```