### PR TITLE
Make users email column case insensitive

### DIFF
--- a/src/base_authentication_app_skeleton/db/migrations/00000000000001_create_users.cr
+++ b/src/base_authentication_app_skeleton/db/migrations/00000000000001_create_users.cr
@@ -1,14 +1,17 @@
 class CreateUsers::V00000000000001 < Avram::Migrator::Migration::V1
   def migrate
+    enable_extension "citext"
+
     create table_for(User) do
       primary_key id : Int64
       add_timestamps
-      add email : String, unique: true
+      add email : String, unique: true, case_sensitive: false
       add encrypted_password : String
     end
   end
 
   def rollback
     drop table_for(User)
+    disable_extension "citext"
   end
 end


### PR DESCRIPTION
Fixes https://github.com/luckyframework/authentic/issues/9
Fixes https://github.com/luckyframework/lucky_cli/issues/597

Before this change, if a user created an account with `Foo@example.com` and then tried to sign in with `foo@example.com` it wouldn't have worked. They could also have made another account with different cases in the email. Now that's not possible.