### PR TITLE
Keep documentation consistent in generated apps

### DIFF
--- a/src/web_app_skeleton/src/actions/api_action.cr.ecr
+++ b/src/web_app_skeleton/src/actions/api_action.cr.ecr
@@ -12,5 +12,8 @@ abstract class ApiAction < Lucky::Action
   # Add 'include Api::Auth::SkipRequireAuthToken' to your actions to allow all requests.
   include Api::Auth::RequireAuthToken
   <%- end -%>
+  
+  # By default all actions are required to use underscores to separate words.
+  # Add 'include Lucky::SkipRouteStyleCheck' to your actions if you wish to ignore this check for specific routes.
   include Lucky::EnforceUnderscoredRoute
 end

--- a/src/web_app_skeleton/src/actions/api_action.cr.ecr
+++ b/src/web_app_skeleton/src/actions/api_action.cr.ecr
@@ -12,7 +12,7 @@ abstract class ApiAction < Lucky::Action
   # Add 'include Api::Auth::SkipRequireAuthToken' to your actions to allow all requests.
   include Api::Auth::RequireAuthToken
   <%- end -%>
-  
+
   # By default all actions are required to use underscores to separate words.
   # Add 'include Lucky::SkipRouteStyleCheck' to your actions if you wish to ignore this check for specific routes.
   include Lucky::EnforceUnderscoredRoute


### PR DESCRIPTION
Added some doc blocks that mimick `RequireAuthToken` to state what `EnforceUnderscoredRoute` is doing, and how to skip it in specific actions.