### PR TITLE
Move app config requirement to the top

### DIFF
--- a/src/web_app_skeleton/src/app.cr.ecr
+++ b/src/web_app_skeleton/src/app.cr.ecr
@@ -5,6 +5,8 @@ require "./shards"
 Lucky::AssetHelpers.load_manifest
 
 <%- end -%>
+require "../config/server"
+require "../config/**"
 require "./app_database"
 require "./models/base_model"
 require "./models/mixins/**"
@@ -24,7 +26,5 @@ require "./components/base_component"
 require "./components/**"
 require "./pages/**"
 <%- end -%>
-require "../config/server"
-require "../config/**"
 require "../db/migrations/**"
 require "./app_server"


### PR DESCRIPTION
I was having an issue with the [rosetta](https://github.com/wout/rosetta/) shard because config files and initializers were loaded after everything in `/src`.

Rosetta requires the locales to be loaded and parsed before the app gets loaded. This happens with the `Rosetta::Backend.load("config/rosetta")` macro. Since config files were loaded last, the compiler couldn't find the locale modules, which are generated from an external file using the `run` macro. So every single locale raised compiler errors:

```
Compiling...
web          | There was a problem expanding macro 't'
web          | 
web          | Code in macro 't'
web          | 
web          |  3 | Rosetta.t("sign_ins.new_page.heading")
web          |      ^
web          | Called macro defined in lib/rosetta/src/rosetta/translation.cr:6:3
web          | 
web          |  6 | macro t(key)
web          | 
web          | Which expanded to:
web          | 
web          |  > 2 | 
web          |  > 3 |     
web          |  > 4 |       Rosetta::Locales::SignIns::NewPage::Heading
web          |              ^------------------------------------------
web          | Error: undefined constant Rosetta::Locales::SignIns::NewPage::Heading
```

Simply moving the config requirement to the top of the list in `src/app.cr` fixed the issue. So far, I can't see any problems with this change and I've tested it with two apps.

I may be wrong, but to me, it makes more sense to load configuration files before loading the rest of the app. Or am I overlooking anything?