### PR TITLE
explicitly sends the manifest file name in generated app

### DIFF
--- a/shard.override.yml
+++ b/shard.override.yml
@@ -3,9 +3,9 @@
 
 # NOTE: https://github.com/crystal-lang/shards/issues/432
 # Until this is resolved, the default needs to be empty here.
-dependencies: {}
+# dependencies: {}
 # Uncomment if you need to override
-# dependencies:
-#   lucky:
-#     github: luckyframework/lucky
-#     branch: master
+dependencies:
+  lucky:
+    github: luckyframework/lucky
+    branch: master

--- a/src/web_app_skeleton/src/app.cr.ecr
+++ b/src/web_app_skeleton/src/app.cr.ecr
@@ -1,8 +1,8 @@
 require "./shards"
 
 <%- if browser? -%>
-# Load the asset manifest in public/mix-manifest.json
-Lucky::AssetHelpers.load_manifest
+# Load the asset manifest
+Lucky::AssetHelpers.load_manifest "public/mix-manifest.json"
 
 <%- end -%>
 require "../config/server"


### PR DESCRIPTION
This change isn't _necessary_ but it might reduce the number of "hey how can I change this" help requests.