### PR TITLE
Explicitly specify `yarn run` for front end tasks

### DIFF
--- a/src/browser_app_skeleton/package.json
+++ b/src/browser_app_skeleton/package.json
@@ -8,9 +8,9 @@
   },
   "scripts": {
     "heroku-postbuild": "yarn prod",
-    "dev": "mix",
-    "watch": "mix watch",
-    "prod": "mix --production"
+    "dev": "yarn run mix",
+    "watch": "yarn run mix watch",
+    "prod": "yarn run mix --production"
   },
   "devDependencies": {
     "@babel/compat-data": "^7.9.0",


### PR DESCRIPTION
- Decreases new-developer friction when Laravel Mix isn't already installed
- prevents a PATH collision if elixir's mix might be available.

Fixes #681

