### PR TITLE
New apps have tagged flow specs

### DIFF
--- a/src/browser_authentication_app_skeleton/spec/flows/authentication_spec.cr
+++ b/src/browser_authentication_app_skeleton/spec/flows/authentication_spec.cr
@@ -1,6 +1,6 @@
 require "../spec_helper"
 
-describe "Authentication flow" do
+describe "Authentication flow", tags: "flow" do
   it "works" do
     flow = AuthenticationFlow.new("test@example.com")
 

--- a/src/browser_authentication_app_skeleton/spec/flows/reset_password_spec.cr
+++ b/src/browser_authentication_app_skeleton/spec/flows/reset_password_spec.cr
@@ -1,6 +1,6 @@
 require "../spec_helper"
 
-describe "Reset password flow" do
+describe "Reset password flow", tags: "flow" do
   it "works" do
     user = UserFactory.create
     flow = ResetPasswordFlow.new(user)


### PR DESCRIPTION
 Fixes #671

A new generated app can now run `crystal spec --tag "flow"` to run just the flow specs, or `--tag "~flow"` to run all specs expect flow.