### PR TITLE
Add postcss plugins to package.json

### DIFF
--- a/src/browser_app_skeleton/package.json
+++ b/src/browser_app_skeleton/package.json
@@ -18,6 +18,8 @@
     "compression-webpack-plugin": "^7.0.0",
     "laravel-mix": "^6.0.0",
     "postcss": "^8.1.0",
+    "postcss-smart-import": "^0.7.6",
+    "postcss-preset-env": "^7.3.0",
     "resolve-url-loader": "^3.1.1",
     "sass": "^1.26.10",
     "sass-loader": "^10.0.2"


### PR DESCRIPTION

Add two postcss plugins to the skeleton app's package.json, permitting mix to run successfully.

fixes #728
