### PR TITLE
Comment out unconfigured RequestIdHandler

### DIFF
--- a/src/web_app_skeleton/config/server.cr.ecr
+++ b/src/web_app_skeleton/config/server.cr.ecr
@@ -47,14 +47,13 @@ Lucky::ForceSSLHandler.configure do |settings|
 end
 
 # Set a unique ID for each HTTP request.
-Lucky::RequestIdHandler.configure do |settings|
-  # To enable the request ID, uncomment the lines below.
-  # You can set your own custom String, or use a random UUID.
-  #
-  # settings.set_request_id = ->(context : HTTP::Server::Context) {
-  #   UUID.random.to_s
-  # }
-end
+# To enable the request ID, uncomment the lines below.
+# You can set your own custom String, or use a random UUID.
+# Lucky::RequestIdHandler.configure do |settings|
+#   settings.set_request_id = ->(context : HTTP::Server::Context) {
+#     UUID.random.to_s
+#   }
+# end
 
 private def secret_key_from_env
   ENV["SECRET_KEY_BASE"]? || raise_missing_secret_key_in_production


### PR DESCRIPTION
A new lucky app results in ameba errors due to this block's contents
being commented out. By commenting out the whole block, we still
provide the user useful configuration information without leaving an
empty block