### PR TITLE
Change default generated app to build a generic target

### DIFF
--- a/spec/integration/init_web_spec.cr
+++ b/spec/integration/init_web_spec.cr
@@ -16,7 +16,6 @@ describe "Initializing a new web project" do
 
       File.delete("test-project/.env")
       compile_and_run_specs_on_test_project
-      File.read("test-project/Procfile").should contain "test_project"
       File.read(".github/workflows/ci.yml").should contain "postgres"
       File.read("test-project/public/mix-manifest.json").should contain "images/cat.gif"
       File.exists?("test-project/public/favicon.ico").should eq true

--- a/src/generators/web.cr
+++ b/src/generators/web.cr
@@ -31,6 +31,7 @@ class LuckyCli::Generators::Web
   def run
     ensure_directory_does_not_exist
     generate_default_crystal_project
+    rename_shard_target_to_app
     add_deps_to_shard_file
     remove_generated_src_files
     remove_generated_spec_files
@@ -148,6 +149,10 @@ class LuckyCli::Generators::Web
       shell: true,
       output: io,
       error: STDERR
+  end
+
+  private def rename_shard_target_to_app
+    replace_text "shard.yml", from: "#{project_name}:", to: "app:"
   end
 
   private def add_deps_to_shard_file

--- a/src/lucky_cli/generator_helpers.cr
+++ b/src/lucky_cli/generator_helpers.cr
@@ -39,6 +39,15 @@ module LuckyCli::GeneratorHelpers
     end
   end
 
+  def replace_text(filename, from, to)
+    within_project do
+      File.write(
+        filename,
+        File.read(filename).gsub(from, to)
+      )
+    end
+  end
+
   def run_command(command)
     within_project do
       Process.run command,

--- a/src/web_app_skeleton/Procfile
+++ b/src/web_app_skeleton/Procfile
@@ -1,0 +1,2 @@
+web: bin/app
+release: lucky db.migrate

--- a/src/web_app_skeleton/Procfile.ecr
+++ b/src/web_app_skeleton/Procfile.ecr
@@ -1,2 +1,0 @@
-web: bin/<%= project_name %>
-release: lucky db.migrate


### PR DESCRIPTION
This allows for easier devops/DX by being able to have a reliable bin/app generated on build
Which greatly cleans up universal Dockerfiles

Resolves #735
