### PR TITLE
Lock down Crystal version to 1.4 or later

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Crystal
         uses: crystal-lang/install-crystal@v1
         with:
-          crystal: 1.3.2
+          crystal: 1.4.1
       - name: Install shards
         run: shards install
       - name: Format
@@ -32,7 +32,7 @@ jobs:
         shard_override_file:
           - shard.override.yml
         crystal_version:
-          - 1.0.0
+          - 1.4.0
           - latest
         experimental:
           - false

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -18,7 +18,7 @@ jobs:
         shard_override_file:
           - shard.override.yml
         crystal_version:
-          - 1.0.0
+          - 1.4.0
           - latest
         experimental:
           - false

--- a/shard.override.yml
+++ b/shard.override.yml
@@ -1,8 +1,6 @@
 # This file is used to override the shards built by
 # generated Lucky apps.
 
-# TODO: Remove this once we only support Crystal >= 1.1.0
-dependencies: {}
 # Uncomment if you need to override
 # dependencies:
 #   lucky:

--- a/shard.yml
+++ b/shard.yml
@@ -8,7 +8,7 @@ targets:
   lucky:
     main: src/lucky.cr
 
-crystal: ">= 1.0.0"
+crystal: ">= 1.4.0"
 
 license: MIT
 
@@ -26,4 +26,4 @@ dependencies:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 0.14.4
+    version: ~> 1.0.0

--- a/src/web_app_skeleton/docker/development.dockerfile
+++ b/src/web_app_skeleton/docker/development.dockerfile
@@ -1,4 +1,4 @@
-FROM crystallang/crystal:1.1.1
+FROM crystallang/crystal:1.4.1
 
 # Add the nodesource ppa to apt. Update this to change the nodejs version.
 RUN wget https://deb.nodesource.com/setup_16.x -O- | bash
@@ -26,7 +26,7 @@ RUN wget https://github.com/DarthSim/overmind/releases/download/v2.2.2/overmind-
 # Install lucky cli, TODO: fetch current lucky version from source code.
 WORKDIR /lucky/cli
 RUN git clone https://github.com/luckyframework/lucky_cli . && \
-    git checkout v0.29.0 && \
+    git checkout v0.30.0 && \
     shards build --without-development && \
     cp bin/lucky /usr/bin
 


### PR DESCRIPTION
# Purpose

Locks Lucky to Crystal version 1.4.0 or later.
# Description

With the release of the new Crystal book being focused on 1.4.0, and shards like Ameba locking to that version, as well as Crystal 1.5.0 is slated to come out in the next 2 months, it makes sense that we start pushing to have everyone use a later version of Crystal. This will also allow us to clean up some code with the assumption that the user is using 1.4.0 or later.
