### PR TITLE
Separating Lucky and Avram

### DIFF
--- a/shard.edge.yml
+++ b/shard.edge.yml
@@ -2,6 +2,9 @@ dependencies:
   lucky:
     github: luckyframework/lucky
     branch: main
+  avram:
+    github: luckyframework/avram
+    branch: main
   authentic:
     github: luckyframework/authentic
     branch: main

--- a/shard.override.yml
+++ b/shard.override.yml
@@ -2,7 +2,10 @@
 # generated Lucky apps.
 
 # Uncomment if you need to override
-# dependencies:
-#   lucky:
-#     github: luckyframework/lucky
-#     branch: main
+dependencies:
+  lucky:
+    github: luckyframework/lucky
+    branch: main
+  avram:
+    github: luckyframework/avram
+    branch: main

--- a/src/generators/web.cr
+++ b/src/generators/web.cr
@@ -172,6 +172,9 @@ class LuckyCli::Generators::Web
       lucky:
         github: luckyframework/lucky
         version: ~> 0.30.0
+      avram:
+        github: luckyframework/avram
+        version: ~> 0.23.0
       carbon:
         github: luckyframework/carbon
         version: ~> 0.2.1

--- a/src/web_app_skeleton/src/shards.cr.ecr
+++ b/src/web_app_skeleton/src/shards.cr.ecr
@@ -3,8 +3,8 @@ require "lucky_env"
 LuckyEnv.load?(".env")
 
 # Require your shards here
-require "avram"
 require "lucky"
+require "avram/lucky"
 require "carbon"
 <%- if generate_auth? -%>
 require "authentic"

--- a/src/web_app_skeleton/tasks.cr
+++ b/src/web_app_skeleton/tasks.cr
@@ -20,5 +20,6 @@ require "./db/migrations/**"
 
 # Load Lucky tasks (dev, routes, etc.)
 require "lucky/tasks/**"
+require "avram/lucky/tasks"
 
 LuckyTask::Runner.run


### PR DESCRIPTION
Closes #697
Replaces #711

Starting with the next release, Avram will no longer be a required component of Lucky. However, Lucky will still be a part of Avram. This transition will give us more flexibility as it will allow you to start building Lucky apps that don't need a database, or allow you to use a different ORM if you chose to.