### PR TITLE
Live-Reload changes for lucky watch

### DIFF
--- a/src/browser_app_skeleton/src/components/shared/layout_head.cr
+++ b/src/browser_app_skeleton/src/components/shared/layout_head.cr
@@ -10,6 +10,11 @@ class Shared::LayoutHead < BaseComponent
       meta name: "turbolinks-cache-control", content: "no-cache"
       csrf_meta_tags
       responsive_meta_tag
+
+      # Used only in development when running `lucky watch`.
+      # Will reload browser whenever files change.
+      # See [docs]()
+      live_reload_connect_tag
     end
   end
 end

--- a/src/web_app_skeleton/config/watch.yml
+++ b/src/web_app_skeleton/config/watch.yml
@@ -1,2 +1,3 @@
 host: 127.0.0.1
 port: 3000
+reload_port: 3001


### PR DESCRIPTION
Ref: https://github.com/luckyframework/lucky/pull/1693

## Added
- `live_reload_connect_tag` in layout_head
- `reload_port` in watch.yml