### PR TITLE
Fixing require order on generated apps

### DIFF
--- a/src/web_app_skeleton/src/app.cr.ecr
+++ b/src/web_app_skeleton/src/app.cr.ecr
@@ -6,8 +6,8 @@ Lucky::AssetHelpers.load_manifest "public/mix-manifest.json"
 
 <%- end -%>
 require "../config/server"
-require "../config/**"
 require "./app_database"
+require "../config/**"
 require "./models/base_model"
 require "./models/mixins/**"
 require "./models/**"


### PR DESCRIPTION
Fixes #768

We use the `AppDatabase` in the `config/` directory before it's required. Crystal hasn't complained about this, but this order helps make it clear.