### PR TITLE
Adding a nicer error when the directory doesn't exist.

### DIFF
--- a/src/generators/web.cr
+++ b/src/generators/web.cr
@@ -16,7 +16,17 @@ class LuckyCli::Generators::Web
     project_directory : String = "."
   )
     @full_project_directory = File.expand_path(project_directory)
-    Dir.cd(@full_project_directory)
+
+    if Dir.exists?(@full_project_directory)
+      Dir.cd(@full_project_directory)
+    else
+      puts <<-ERROR.colorize.red
+      The directory #{@full_project_directory} does not exist.
+      Make sure to create the directory first before generating a new application.
+      ERROR
+
+      exit(1)
+    end
     @default_directory = project_directory == "."
 
     @project_dir = project_name


### PR DESCRIPTION
Fixes #766

I decided to go with a `puts/exit` combo instead of raising an exception because the stacktrace here is irrelevant. 