### PR TITLE
don't copy and encrypt the password if it's invalid.

### DIFF
--- a/src/base_authentication_app_skeleton/src/operations/sign_up_user.cr
+++ b/src/base_authentication_app_skeleton/src/operations/sign_up_user.cr
@@ -9,6 +9,6 @@ class SignUpUser < User::SaveOperation
 
   before_save do
     validate_uniqueness_of email
-    Authentic.copy_and_encrypt password, to: encrypted_password
+    Authentic.copy_and_encrypt(password, to: encrypted_password) if password.valid?
   end
 end


### PR DESCRIPTION
Fixes Lucky https://github.com/luckyframework/lucky/issues/1672

The password validations run before this happens, but if your password isn't valid, we shouldn't copy and encrypt. 