### PR TITLE
Problem when executing lucky db.migrate

### DIFF
--- a/src/web_app_skeleton/src/shards.cr.ecr
+++ b/src/web_app_skeleton/src/shards.cr.ecr
@@ -4,7 +4,7 @@ LuckyEnv.load?(".env")
 
 # Require your shards here
 require "lucky"
-require "avram/lucky"
+require "avram"
 require "carbon"
 <%- if generate_auth? -%>
 require "authentic"

--- a/src/web_app_skeleton/tasks.cr
+++ b/src/web_app_skeleton/tasks.cr
@@ -20,6 +20,6 @@ require "./db/migrations/**"
 
 # Load Lucky tasks (dev, routes, etc.)
 require "lucky/tasks/**"
-require "avram/lucky/tasks"
+require "avram/tasks"
 
 LuckyTask::Runner.run


### PR DESCRIPTION
I'm not a Crystal specialist, but there seems to be a typo here

```bash
web          | Showing last frame. Use --error-trace for full trace.
web          |
web          | In src/shards.cr:7:1
web          |
web          |  7 | require "avram/lucky"
web          |      ^
web          | Error: can't find file 'avram/lucky'
web          |
web          | If you're trying to require a shard:
web          | - Did you remember to run `shards install`?
web          | - Did you make sure you're running the compiler in the same directory as your shard.yml?
web          | Done
```