### PR TITLE
Ripping out Turbolinks now that it's been deprecated and archived.

### DIFF
--- a/src/browser_app_skeleton/package.json
+++ b/src/browser_app_skeleton/package.json
@@ -3,8 +3,7 @@
   "private": true,
   "dependencies": {
     "@rails/ujs": "^6.0.0",
-    "modern-normalize": "^1.1.0",
-    "turbolinks": "^5.2.0"
+    "modern-normalize": "^1.1.0"
   },
   "scripts": {
     "heroku-postbuild": "yarn prod",

--- a/src/browser_app_skeleton/src/components/shared/layout_head.cr
+++ b/src/browser_app_skeleton/src/components/shared/layout_head.cr
@@ -5,9 +5,8 @@ class Shared::LayoutHead < BaseComponent
     head do
       utf8_charset
       title "My App - #{@page_title}"
-      css_link asset("css/app.css"), data_turbolinks_track: "reload"
-      js_link asset("js/app.js"), defer: "true", data_turbolinks_track: "reload"
-      meta name: "turbolinks-cache-control", content: "no-cache"
+      css_link asset("css/app.css")
+      js_link asset("js/app.js"), defer: "true"
       csrf_meta_tags
       responsive_meta_tag
 

--- a/src/browser_app_skeleton/src/js/app.js
+++ b/src/browser_app_skeleton/src/js/app.js
@@ -4,11 +4,3 @@
 // Though it says "Rails" it actually works with any framework.
 require("@rails/ujs").start();
 
-// Turbolinks is optional. Learn more: https://github.com/turbolinks/turbolinks/
-require("turbolinks").start();
-
-// If using Turbolinks, you can attach events to page load like this:
-//
-// document.addEventListener("turbolinks:load", function() {
-//   ...
-// })


### PR DESCRIPTION
Ref #629

We've discussed replacing turbolinks with turbo, but for now I'm just removing turbolinks as default now that the [repo](https://github.com/turbolinks/turbolinks-classic) has been marked as archived. Existing projects using it will still have the ability to use it, but new generated projects won't come with it by default. That will allow us to figure out how to add in turbo (if that's what we want....). Though, Lucky is pretty fast without it :joy:  