### PR TITLE
Chore: dockerfile dev fixes (gunzip, bump lucky-cli)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ Run `which lucky` from the command line to make sure it is installed.
 ## Contributing
 
 1.  Fork it ( https://github.com/luckyframework/lucky_cli/fork )
-1.  Create your feature branch (git checkout -b my-new-feature)
-1.  Commit your changes (git commit -am 'Add some feature')
-1.  Push to the branch (git push origin my-new-feature)
-1.  Check that specs on GitHub Actions CI pass
-1.  Create a new Pull Request
+2.  Create your feature branch (git checkout -b my-new-feature)
+3.  Commit your changes (git commit -am 'Add some feature')
+4.  Push to the branch (git push origin my-new-feature)
+5.  Check that specs on GitHub Actions CI pass
+6.  Create a new Pull Request
 
 ## Testing Deployment to Heroku
 
@@ -47,11 +47,11 @@ run tests against Heroku to make sure deployment is working as expected.
 If you want though, you can also test deployment locally:
 
 1. Sign up for a Heroku account and install the CLI.
-1. Run `heroku authorizations:create --description="Lucky CLI Integration Tests"`.
-1. Grab the token from that command and put it in the generated `.env` file.
-1. Change `RUN_HEROKU_SPECS` from `0` to `1` in the `.env` file.
-1. Run `script/setup` to make sure all dependencies are installed.
-1. Run `script/test` to test everything, or run `script/test specs/integration/deploy_to_heroku_spec.cr`
+2. Run `heroku authorizations:create --description="Lucky CLI Integration Tests"`.
+3. Grab the token from that command and put it in the generated `.env` file.
+4. Change `RUN_HEROKU_SPECS` from `0` to `1` in the `.env` file.
+5. Run `script/setup` to make sure all dependencies are installed.
+6. Run `script/test` to test everything, or run `script/test specs/integration/deploy_to_heroku_spec.cr`
 
 ## Contributors
 

--- a/src/web_app_skeleton/docker/development.dockerfile
+++ b/src/web_app_skeleton/docker/development.dockerfile
@@ -2,7 +2,7 @@ FROM crystallang/crystal:1.4.1
 
 # Install utilities required to make this Dockerfile run
 RUN apt-get update && \
-    apt-get install -y wget gunzip
+    apt-get install -y wget
 
 # Add the nodesource ppa to apt. Update this to change the nodejs version.
 RUN wget https://deb.nodesource.com/setup_16.x -O- | bash

--- a/src/web_app_skeleton/docker/development.dockerfile
+++ b/src/web_app_skeleton/docker/development.dockerfile
@@ -30,7 +30,7 @@ RUN wget https://github.com/DarthSim/overmind/releases/download/v2.2.2/overmind-
 # Install lucky cli, TODO: fetch current lucky version from source code.
 WORKDIR /lucky/cli
 RUN git clone https://github.com/luckyframework/lucky_cli . && \
-    git checkout v0.30.0 && \
+    git checkout v1.0.0-rc1 && \
     shards build --without-development && \
     cp bin/lucky /usr/bin
 


### PR DESCRIPTION
Hello LuckyCLI Team,

I am new to _Crystal world_ and wanted to give a try without installing various dependencies on my host (like configuring postgresql :see_no_evil: ), but current dev dockerfile generated by Lucky CLI had some issues:

| :whale: step | Command | Error | Comment |
| --- | ---  | --- | --- |
| STEP2 | `apt-get install -y wget gzip` |  `Unable to locate package gunzip` |  `gunzip` is already installed from the base image `crystal:1.4.1`. If it was missing I guess `gzip` is the package to install to get gunzip, gzip and zcat |
| STEP8 |  `git checkout v0.30.0` | N/A | Cf https://github.com/luckyframework/lucky_cli/issues/781, I was expecting to get the latest release. I just did another hardcoded bump for now |

**How it has been tested ?**
After this PR I was able to build and run the container with various lucky cli
* `lucky --version` => `1.0.0-rc1` 
* `lucky init` working too

Now I have to try the framework :smiley:

PS: maybe worth it mentioning in the doc https://luckyframework.org/guides/getting-started/installing that docker and compose templates are available ? That's a great feature !