### PR TITLE
Add type to memoize arg

### DIFF
--- a/spec/support/with_project_cleanup.cr
+++ b/spec/support/with_project_cleanup.cr
@@ -1,5 +1,5 @@
 module WithProjectCleanup
-  private def with_project_cleanup(project_directory = "test-project", skip_db_drop = false) : Nil
+  private def with_project_cleanup(project_directory = "test-project", skip_db_drop = false, &) : Nil
     yield
 
     FileUtils.cd(project_directory) {

--- a/src/api_authentication_app_skeleton/src/models/user_token.cr
+++ b/src/api_authentication_app_skeleton/src/models/user_token.cr
@@ -22,7 +22,7 @@ class UserToken
   end
 
   # Used in tests to return a fake token to test against.
-  def self.stub_token(token : String)
+  def self.stub_token(token : String, &)
     temp_config(stubbed_token: token) do
       yield
     end

--- a/src/app_with_sec_tester/spec/flows/security_spec.cr.ecr
+++ b/src/app_with_sec_tester/spec/flows/security_spec.cr.ecr
@@ -116,7 +116,7 @@ describe "SecTester" do
   <%- end -%>
 end
 
-private def scan_with_cleanup : Nil
+private def scan_with_cleanup(&) : Nil
   scanner = LuckySecTester.new
   yield scanner
 ensure

--- a/src/browser_app_skeleton/src/actions/browser_action.cr.ecr
+++ b/src/browser_app_skeleton/src/actions/browser_action.cr.ecr
@@ -40,7 +40,7 @@ abstract class BrowserAction < Lucky::Action
 
   # This method tells Authentic how to find the current user
   # The 'memoize' macro makes sure only one query is issued to find the user
-  private memoize def find_current_user(id) : User?
+  private memoize def find_current_user(id : User::PrimaryKeyType) : User?
     UserQuery.new.id(id).first?
   end
   <%- end -%>

--- a/src/browser_app_skeleton/src/actions/browser_action.cr.ecr
+++ b/src/browser_app_skeleton/src/actions/browser_action.cr.ecr
@@ -40,7 +40,7 @@ abstract class BrowserAction < Lucky::Action
 
   # This method tells Authentic how to find the current user
   # The 'memoize' macro makes sure only one query is issued to find the user
-  private memoize def find_current_user(id : User::PrimaryKeyType) : User?
+  private memoize def find_current_user(id : String | User::PrimaryKeyType) : User?
     UserQuery.new.id(id).first?
   end
   <%- end -%>

--- a/src/browser_app_skeleton/src/components/shared/field.cr
+++ b/src/browser_app_skeleton/src/components/shared/field.cr
@@ -35,7 +35,7 @@ class Shared::Field(T) < BaseComponent
   needs attribute : Avram::PermittedAttribute(T)
   needs label_text : String?
 
-  def render
+  def render(&)
     label_for attribute, label_text
 
     # You can add more default options here. For example:

--- a/src/browser_authentication_app_skeleton/spec/support/flows/reset_password_flow.cr
+++ b/src/browser_authentication_app_skeleton/spec/support/flows/reset_password_flow.cr
@@ -34,7 +34,7 @@ class ResetPasswordFlow < BaseFlow
     click "@update-password-button"
   end
 
-  private def with_fake_token
+  private def with_fake_token(&)
     PasswordResetRequestEmail.temp_config(stubbed_token: "fake") do
       yield
     end

--- a/src/build_and_run_task.cr
+++ b/src/build_and_run_task.cr
@@ -61,7 +61,7 @@ class LuckyCli::BuildAndRunTask
     ).exit_code
   end
 
-  private def with_spinner(start_text)
+  private def with_spinner(start_text, &)
     if ENV.has_key?("CI")
       STDERR.puts start_text.colorize.bold
       yield

--- a/src/generators/web.cr
+++ b/src/generators/web.cr
@@ -246,7 +246,7 @@ class LuckyCli::Generators::Web
         append_text to: "shard.yml", text: <<-DEPS_LIST
           lucky_sec_tester:
             github: luckyframework/lucky_sec_tester
-            version: ~> 0.1.0
+            version: ~> 0.2.0
         DEPS_LIST
       end
     end

--- a/src/lucky_cli/generator_helpers.cr
+++ b/src/lucky_cli/generator_helpers.cr
@@ -57,7 +57,7 @@ module LuckyCli::GeneratorHelpers
     end
   end
 
-  private def within_project
+  private def within_project(&)
     FileUtils.cd project_dir do
       yield
     end

--- a/src/lucky_cli/spinner.cr
+++ b/src/lucky_cli/spinner.cr
@@ -33,7 +33,7 @@ class LuckyCli::Spinner
   )
   end
 
-  def self.start(*args, **named_args)
+  def self.start(*args, **named_args, &)
     spinner = new(*args, **named_args).start
     yield.tap do |_last_value_from_block|
       spinner.stop


### PR DESCRIPTION
This fixes a compilation error that causes

```
▸ Creating the database
Showing last frame. Use --error-trace for full trace.

In src/app.cr:21:1

 21 | require "./actions/**"
      ^
Error: All arguments must have an explicit type restriction for memoized methods
```

