### PR TITLE
Update the generate Docker setup

### DIFF
--- a/src/web_app_skeleton/README.md.ecr
+++ b/src/web_app_skeleton/README.md.ecr
@@ -9,6 +9,15 @@ This is a project written using [Lucky](https://luckyframework.org). Enjoy!
 1. Run `script/setup`
 1. Run `lucky dev` to start the app
 
+### Using Docker for development
+
+1. [Install Docker](https://docs.docker.com/engine/install/)
+1. Run `docker compose up`
+
+The Docker container will boot all of the necessary components needed to run your Lucky application.
+To configure the container, update the `docker-compose.yml` file, and the `docker/development.dockerfile` file.
+
+
 ### Learning Lucky
 
 Lucky uses the [Crystal](https://crystal-lang.org) programming language. You can learn about Lucky from the [Lucky Guides](https://luckyframework.org/guides/getting-started/why-lucky).

--- a/src/web_app_skeleton/docker-compose.yml
+++ b/src/web_app_skeleton/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       dockerfile: docker/development.dockerfile
     environment:
       DATABASE_URL: postgres://lucky:password@postgres:5432/lucky
+      DEV_HOST: "0.0.0.0"
     volumes:
       - type: bind
         source: .
@@ -19,7 +20,8 @@ services:
     depends_on:
       - postgres
     ports:
-      - 5001:5001
+      - 3000:3000 # This is the Lucky Server port
+      - 3001:3001 # This is the Lucky watcher reload port
 
     entrypoint: ["docker/dev_entrypoint.sh"]
 

--- a/src/web_app_skeleton/docker/dev_entrypoint.sh.ecr
+++ b/src/web_app_skeleton/docker/dev_entrypoint.sh.ecr
@@ -2,9 +2,9 @@
 
 set -euo pipefail
 
-# This is the entrypoint script used for development docker workflows. By
-# default it will:
-#  - Install shards.
+# This is the entrypoint script used for development docker workflows.
+# By default it will:
+#  - Install dependencies.
 #  - Run migrations.
 #  - Start the dev server.
 # It also accepts any commands to be run instead.
@@ -27,10 +27,10 @@ if ! [ -d bin ] ; then
   echo "Creating bin directory"
   mkdir bin
 fi
-
+<%- if browser? -%>
 echo "Installing npm packages..."
 yarn install
-
+<%- end -%>
 if ! shards check ; then
   echo "Installing shards..."
   shards install
@@ -42,11 +42,6 @@ echo "Waiting for postgres to be available..."
 if ! psql -d "$DATABASE_URL" -c '\d migrations' > /dev/null ; then
   echo "Finishing database setup..."
   lucky db.migrate
-fi
-
-if [ -S .overmind.sock ] ; then
-  echo "Removing old overmind socket file..."
-  rm .overmind.sock
 fi
 
 echo "Starting lucky dev server..."

--- a/src/web_app_skeleton/docker/development.dockerfile.ecr
+++ b/src/web_app_skeleton/docker/development.dockerfile.ecr
@@ -1,9 +1,9 @@
-FROM crystallang/crystal:1.4.1
+FROM crystallang/crystal:<%= Crystal::VERSION %>
 
 # Install utilities required to make this Dockerfile run
 RUN apt-get update && \
     apt-get install -y wget
-
+<%- if browser? -%>
 # Add the nodesource ppa to apt. Update this to change the nodejs version.
 RUN wget https://deb.nodesource.com/setup_16.x -O- | bash
 
@@ -20,21 +20,25 @@ RUN apt-get update && \
 #    browser app.
 #  - Mix is the default asset compiler.
 RUN npm install -g yarn mix
+<%- else -%>
 
-# Installs overmind, not needed if nox is the process manager.
-RUN wget https://github.com/DarthSim/overmind/releases/download/v2.2.2/overmind-v2.2.2-linux-amd64.gz && \
-    gunzip overmind-v2.2.2-linux-amd64.gz && \
-    mv overmind-v2.2.2-linux-amd64 /usr/bin/overmind && \
-    chmod +x /usr/bin/overmind
+# Apt installs:
+# - Postgres cli tools are required for lucky-cli.
+# - tmux is required for the Overmind process manager.
+RUN apt-get update && \
+    apt-get install -y postgresql-client tmux && \
+    rm -rf /var/lib/apt/lists/*
+<%- end -%>
 
-# Install lucky cli, TODO: fetch current lucky version from source code.
+# Install lucky cli
 WORKDIR /lucky/cli
 RUN git clone https://github.com/luckyframework/lucky_cli . && \
-    git checkout v1.0.0-rc1 && \
+    git checkout v<%= LuckyCli::VERSION %> && \
     shards build --without-development && \
     cp bin/lucky /usr/bin
 
 WORKDIR /app
 ENV DATABASE_URL=postgres://postgres:postgres@host.docker.internal:5432/postgres
-EXPOSE 5001
+EXPOSE 3000
+EXPOSE 3001
 


### PR DESCRIPTION
Fixes #786
Fixes #792
Fixes #789
Fixes #781

In the next Lucky release, we now have a `DEV_HOST` ENV that can override the host. This value is now set when generating the Docker container so you can still connect to it since 127.0.0.1 is in the container itself. The Dockerfile now knows about the Crystal version you have installed locally when installing Lucky CLI as well as optionally adding in Node so when you generate an API only app, the Dockerfile boots a lot quicker.. Lastly, I removed Overmind since it's not needed with Nox being default.

I was able to test this by building a new Lucky binary from this branch, then generated both a web and API projects. I was able to run both `./script/setup && lucky dev` as well as `docker compose up` to booth both apps.  