### PR TITLE
If the CSRF is disabled, also remove the metatags.

### DIFF
--- a/src/browser_app_skeleton/src/components/shared/layout_head.cr
+++ b/src/browser_app_skeleton/src/components/shared/layout_head.cr
@@ -7,12 +7,27 @@ class Shared::LayoutHead < BaseComponent
       title "My App - #{@page_title}"
       css_link asset("css/app.css")
       js_link asset("js/app.js"), defer: "true"
-      csrf_meta_tags
+      csrf_meta_tags if include_csrf_tag?
       responsive_meta_tag
 
       # Development helper used with the `lucky watch` command.
       # Reloads the browser when files are updated.
       live_reload_connect_tag if LuckyEnv.development?
     end
+  end
+
+  # Cross Site Request Forgery protection is
+  # enabled by default. This includes a hidden input
+  # used in forms when using the `form_for` method.
+  #
+  # This can be disabled by creating a new `config/forms.cr`
+  # file, and setting this to `false`.
+  # ```
+  # Lucky::FormHelpers.configure do |settings|
+  #   settings.include_csrf_tag = false
+  # end
+  # ```
+  private def include_csrf_tag? : Bool
+    Lucky::FormHelpers.settings.include_csrf_tag
   end
 end


### PR DESCRIPTION
Fixes #696

This is to coincide with 
https://github.com/luckyframework/lucky/blob/22fcb187c2045a36823a03310d1ed68aec5d8f0b/src/lucky/tags/form_helpers.cr#L1C1-L8
