### PR TITLE
Pass custom task args to the tasks

### DIFF
--- a/spec/integration/task_spec.cr
+++ b/spec/integration/task_spec.cr
@@ -32,7 +32,7 @@ private def run(process, output = STDOUT)
 end
 
 private def task(task_name)
-  run("crystal spec/tasks.cr --no-debug -- #{task_name}")
+  run("crystal run --no-debug spec/tasks.cr -- #{task_name}")
 end
 
 private def be_successful

--- a/spec/lucky_spec.cr
+++ b/spec/lucky_spec.cr
@@ -1,0 +1,41 @@
+require "./spec_helper"
+
+describe "Lucky CLI" do
+  describe "getting help" do
+    it "returns the lucky CLI help message when passing the -h flag" do
+      output = IO::Memory.new
+      Process.run("crystal", [lucky_command, "-h"], output: output)
+      output.rewind
+      output.to_s.should contain("Usage: lucky [command]")
+    end
+
+    it "returns the proper help message for built-in CLI commands" do
+      output = IO::Memory.new
+      Process.run("crystal", [lucky_command, "tasks", "-h"], env: lucky_env, output: output)
+      output.rewind
+      output.to_s.should contain("Usage: lucky tasks")
+
+      output = IO::Memory.new
+      Process.run("crystal", [lucky_command, "dev", "-h"], env: lucky_env, output: output)
+      output.rewind
+      output.to_s.should contain("Usage: lucky dev")
+    end
+
+    it "returns custom help messages from custom tasks" do
+      output = IO::Memory.new
+      # NOTE: This must be `error` because of how the messages are printed out from the custom tasks
+      # TODO: Figure out if that's correct, or needs to change
+      Process.run("crystal", [lucky_command, "placeholder_task", "-h"], env: lucky_env, error: output)
+      output.rewind
+      output.to_s.should contain("Custom help message")
+    end
+  end
+end
+
+private def lucky_env : Hash(String, String)
+  {"LUCKY_TASKS_FILE" => Path["spec/tasks.cr"].to_s}
+end
+
+private def lucky_command : String
+  Path["src/lucky.cr"].to_s
+end

--- a/spec/tasks.cr
+++ b/spec/tasks.cr
@@ -2,8 +2,12 @@ require "../src/lucky_cli"
 
 class PlaceholderTask < LuckyTask::Task
   summary "placeholder"
+  help_message "Custom help message"
+  switch :test_mode, "Run in test mode."
 
-  def call; end
+  def call
+    output.puts "Calling Placeholder. Test: #{test_mode?}"
+  end
 end
 
 class TaskWithInput < LuckyTask::Task

--- a/src/lucky.cr
+++ b/src/lucky.cr
@@ -27,6 +27,10 @@ private def precompiled_task_path : String?
   end
 end
 
+private def built_in_commands : Array(String)
+  ["dev", "tasks", "init", "init.custom"]
+end
+
 private def print_lucky_app_not_detected_error
   puts <<-ERROR
 
@@ -51,7 +55,7 @@ options = OptionParser.new do |parser|
     parser.on("dev", "Boot the lucky development server") do
       run_dev_server = true
       parser.banner = "Usage: lucky dev"
-      parser.on("-h", "--help", "Display lucky dev help menu") {
+      parser.on("-h", "--help", "Display lucky dev help menu") do
         puts <<-MESSAGE
         Usage: lucky dev
 
@@ -60,16 +64,16 @@ options = OptionParser.new do |parser|
         are booted.
         MESSAGE
         exit
-      }
+      end
     end
 
-    parser.on("tasks", "Display a list of the tasks available in your app") {
+    parser.on("tasks", "Display a list of the tasks available in your app") do
       # This passes the help flag to LuckyTask within your app to
       # generate a list of available tasks, and bypasses the help
       # flag for this parser
       args = "-h"
       parser.banner = "Usage: lucky tasks"
-      parser.on("-h", "--help", "Display the lucky tasks help menu") {
+      parser.on("-h", "--help", "Display the lucky tasks help menu") do
         puts <<-MESSAGE
         Usage: lucky tasks
 
@@ -80,22 +84,31 @@ options = OptionParser.new do |parser|
         To compile your tasks, build the tasks.cr file
         > crystal build tasks.cr -o bin/tasks
 
+        Then run your tasks file with your task
+        > ./bin/tasks my.task -m --task=1
+
         MESSAGE
         exit
-      }
-    }
+      end
+    end
+
+    if ARGV.size > 1 && !built_in_commands.includes?(task_name)
+      # This stops the CLI parsing options beyond this point.
+      # It allows args to be passed to custom CLI tasks
+      parser.stop
+    end
   else
     parser.on("init", "Start the Lucky wizard") do
       start_wizard = true
       parser.banner = "Usage: lucky init"
-      parser.on("-h", "--help", "Display lucky init help menu") {
+      parser.on("-h", "--help", "Display lucky init help menu") do
         puts <<-MESSAGE
         Usage: lucky init
 
         Run this to start the new application wizard.
         MESSAGE
         exit
-      }
+      end
     end
 
     parser.on("init.custom", "Generate a new Lucky application") do
@@ -105,10 +118,10 @@ options = OptionParser.new do |parser|
     end
   end
 
-  parser.on("-v", "--version", "Show the version of the LuckyCLI") {
+  parser.on("-v", "--version", "Show the version of the LuckyCLI") do
     puts LuckyCli::VERSION
     exit
-  }
+  end
 
   parser.on("-h", "--help", "Show this help") do
     puts parser


### PR DESCRIPTION
Fixes #816 

When I added in https://github.com/luckyframework/lucky_cli/pull/771 It allowed you to run `lucky -h` without waiting on your app to compile. The side affect to this was when you try to pass args to a custom task, the `OptionParser` in here would swallow those and fail. Something as simple as `lucky db.create -h` would return the same help as `lucky -h`. 

In order to tell the OptionParser to stop parsing args, we can use the `parser.stop`. This essentially places a `--` in the spot where we stop the parser.