### PR TITLE
Adding missing log initialization for new Avram.

### DIFF
--- a/src/web_app_skeleton/config/log.cr.ecr
+++ b/src/web_app_skeleton/config/log.cr.ecr
@@ -34,6 +34,14 @@ Lucky::ContinuedPipeLog.dexter.configure(:none)
 # Set the log to ':info' to log all queries
 Avram::QueryLog.dexter.configure(:none)
 
+{% if compare_versions(Avram::VERSION, "1.0.0") > 0 %}
+# This will subscribe to Pulsar events to log when queries
+# are made, queries fail, or save operations fail. Comment
+# this out to disable these log events without turning off
+# all logging.
+Avram.initialize_logging
+{% end %}
+
 # Skip logging static assets requests in development
 Lucky::LogHandler.configure do |settings|
   if LuckyEnv.development?

--- a/src/web_app_skeleton/config/log.cr.ecr
+++ b/src/web_app_skeleton/config/log.cr.ecr
@@ -34,13 +34,10 @@ Lucky::ContinuedPipeLog.dexter.configure(:none)
 # Set the log to ':info' to log all queries
 Avram::QueryLog.dexter.configure(:none)
 
-{% if compare_versions(Avram::VERSION, "1.0.0") > 0 %}
-# This will subscribe to Pulsar events to log when queries
-# are made, queries fail, or save operations fail. Comment
-# this out to disable these log events without turning off
-# all logging.
+# Subscribe to Pulsar events to log when queries are made,
+# queries fail, or save operations fail. Remove this to
+# disable these log events without disabling all logging.
 Avram.initialize_logging
-{% end %}
 
 # Skip logging static assets requests in development
 Lucky::LogHandler.configure do |settings|


### PR DESCRIPTION
Fixes #822

This is only needed for Avram 1.1.0 or later. Though, now that I look at it like this, if you generate a new app, it'll default to Avram 1.1.0. You'd have to manually downgrade for this to affect you. If you're upgrading an existing app, then it would be up to you to add this anyway :thinking:  Maybe we don't need to run the comparison here...