### PR TITLE
chore: remove dependabot npm + monthly gha check

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,16 +4,5 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: monthly
     target-branch: main
-    reviewers:
-      - stephendolan
-
-  - package-ecosystem: npm
-    directory: "/fixtures/browser_src_template/expected"
-    schedule:
-      interval: daily
-    target-branch: main
-    versioning-strategy: increase
-    reviewers:
-      - stephendolan


### PR DESCRIPTION
context: we aren't feeling like we get a lot of benefit out of dependabot right now, and it's a constant moving-bullet to maintain. maybe we'll add it back in the future, or maybe it'll make more in a different repository.