### PR TITLE
Chore: e2e-security should be in weekly ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,19 +63,3 @@ jobs:
       - name: Run build
         run: |
           earthly +gh-action-e2e
-
-  e2e-security-specs:
-    needs: integration-specs
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: earthly/actions-setup@v1
-        with:
-          version: v0.8.0
-      - uses: actions/checkout@v4
-      - name: Run build
-        run: |
-          earthly +gh-action-e2e-security
-        env:
-          EARTHLY_SECRETS: "BRIGHT_TOKEN=${{ secrets.BRIGHT_API_KEY }},BRIGHT_PROJECT_ID=${{ secrets.BRIGHT_PROJECT_ID }}"
-          EARTHLY_BUILD_ARGS: "github_ref=${{ github.ref }},github_sha=${{ github.sha }},github_run_id=${{ github.run_id }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,7 @@ jobs:
           sha_="$(curl -sL $url_ | sha256sum | awk '{print $1}')"
           version_="$(yq '.version' shard.yml)"
 
+          set -x
           gh workflow run release.yml \
             -R luckyframework/homebrew-lucky \
             -f url=$url_ \
@@ -105,6 +106,7 @@ jobs:
           sha_="$(curl -sL $url_.sha256)"
           version_="$(yq '.version' shard.yml)"
 
+          set -x
           gh workflow run release.yml \
             -R luckyframework/scoop-bucket \
             -f url=$url_ \

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -21,3 +21,18 @@ jobs:
       - name: Run build
         run: |
           earthly +gh-action-weekly
+
+  e2e-security-specs:
+    needs: integration-specs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: earthly/actions-setup@v1
+        with:
+          version: v0.8.0
+      - uses: actions/checkout@v4
+      - name: Run build
+        run: |
+          earthly +gh-action-e2e-security
+        env:
+          EARTHLY_SECRETS: "BRIGHT_TOKEN=${{ secrets.BRIGHT_API_KEY }},BRIGHT_PROJECT_ID=${{ secrets.BRIGHT_PROJECT_ID }}"
+          EARTHLY_BUILD_ARGS: "github_ref=${{ github.ref }},github_sha=${{ github.sha }},github_run_id=${{ github.run_id }}"


### PR DESCRIPTION
And now `gh workflow run` will be output to stdout when run (for easier manual releases if it fails)