### PR TITLE
Compare Wizard answers in lowercase for a little leeway

### DIFF
--- a/src/lucky_cli/wizard/labeled_yes_no_question.cr
+++ b/src/lucky_cli/wizard/labeled_yes_no_question.cr
@@ -15,7 +15,7 @@ class LuckyCli::Wizard::LabeledYesNoQuestion
   def ask : Bool
     print question_text.colorize.bold.to_s +
           " (#{yes_label}/#{no_label}): ".colorize.green.bold.to_s
-    answer = gets.try(&.strip.gsub("'", ""))
+    answer = gets.try(&.strip.gsub("'", "").downcase)
     case answer
     when yes_label
       true


### PR DESCRIPTION
Fixes #856

I had entered "Y" for the want auth and it failed. The default values are all lowercase, so we just compare against the lowercase answers just in case.