### PR TITLE
Updates generated BaseSerializer

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -167,6 +167,7 @@ base-specs-image:
     RUN shards install
 
 e2e-base-image:
+    COPY shard.override.yml ./
     RUN apt-get update \
      && apt-get install -y postgresql-client ca-certificates curl gnupg libnss3 libnss3-dev wget \
      && mkdir -p /etc/apt/keyrings \
@@ -178,6 +179,7 @@ e2e-base-image:
      && wget -O /tmp/google-chrome-stable_current_amd64.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
      && apt-get install -y /tmp/google-chrome-stable_current_amd64.deb
     ENV CHROME_BIN=/usr/bin/google-chrome
+    ENV SHARDS_OVERRIDE=$(pwd)/shard.override.yml
     COPY +build-lucky/lucky /usr/bin/lucky
 
 e2e-image:

--- a/fixtures/src_template/expected/src/serializers/base_serializer.cr
+++ b/fixtures/src_template/expected/src/serializers/base_serializer.cr
@@ -1,5 +1,7 @@
-abstract class BaseSerializer < Lucky::Serializer
-  def self.for_collection(collection : Enumerable, *args, **named_args)
+abstract class BaseSerializer
+  include Lucky::Serializable
+
+  def self.for_collection(collection : Enumerable, *args, **named_args) : Array(self)
     collection.map do |object|
       new(object, *args, **named_args)
     end

--- a/fixtures/src_template__api_only/expected/src/serializers/base_serializer.cr
+++ b/fixtures/src_template__api_only/expected/src/serializers/base_serializer.cr
@@ -1,5 +1,7 @@
-abstract class BaseSerializer < Lucky::Serializer
-  def self.for_collection(collection : Enumerable, *args, **named_args)
+abstract class BaseSerializer
+  include Lucky::Serializable
+
+  def self.for_collection(collection : Enumerable, *args, **named_args) : Array(self)
     collection.map do |object|
       new(object, *args, **named_args)
     end

--- a/fixtures/src_template__generate_auth/expected/src/serializers/base_serializer.cr
+++ b/fixtures/src_template__generate_auth/expected/src/serializers/base_serializer.cr
@@ -1,5 +1,7 @@
-abstract class BaseSerializer < Lucky::Serializer
-  def self.for_collection(collection : Enumerable, *args, **named_args)
+abstract class BaseSerializer
+  include Lucky::Serializable
+
+  def self.for_collection(collection : Enumerable, *args, **named_args) : Array(self)
     collection.map do |object|
       new(object, *args, **named_args)
     end

--- a/fixtures/src_template__sec_tester/expected/src/serializers/base_serializer.cr
+++ b/fixtures/src_template__sec_tester/expected/src/serializers/base_serializer.cr
@@ -1,5 +1,7 @@
-abstract class BaseSerializer < Lucky::Serializer
-  def self.for_collection(collection : Enumerable, *args, **named_args)
+abstract class BaseSerializer
+  include Lucky::Serializable
+
+  def self.for_collection(collection : Enumerable, *args, **named_args) : Array(self)
     collection.map do |object|
       new(object, *args, **named_args)
     end

--- a/src/web_app_skeleton/src/serializers/base_serializer.cr.ecr
+++ b/src/web_app_skeleton/src/serializers/base_serializer.cr.ecr
@@ -1,5 +1,7 @@
-abstract class BaseSerializer < Lucky::Serializer
-  def self.for_collection(collection : Enumerable, *args, **named_args)
+abstract class BaseSerializer
+  include Lucky::Serializable
+
+  def self.for_collection(collection : Enumerable, *args, **named_args) : Array(self)
     collection.map do |object|
       new(object, *args, **named_args)
     end


### PR DESCRIPTION
Fixes #876 

In https://github.com/luckyframework/lucky/pull/1947 The Lucky::Serializer was moved to a module to allow for flexibility with your serializers. You can now choose if you need them to be classes or structs just by including the module. 